### PR TITLE
Add a dependabot file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This manages Github action and uv dependencies. At the time of putting this together uv support has only just launched for uv and looks to have some issues, so this is a bit of a 🤞 change.