### PR TITLE
Add Github action linting

### DIFF
--- a/.github/workflows/action-lint.yaml
+++ b/.github/workflows/action-lint.yaml
@@ -1,0 +1,17 @@
+name: Lint GitHub Actions
+on:
+  push:
+    branches:
+      - main
+    paths: ['.github/**']
+  pull_request:
+    paths: ['.github/**']
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          show-progress: false
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main


### PR DESCRIPTION
This action has been configured for all over GOV.UK repos so we should set it up for this one too for consistency.