### PR TITLE
Use None as default option for bool CLI options

### DIFF
--- a/govuk_chat_evaluation/config.py
+++ b/govuk_chat_evaluation/config.py
@@ -22,7 +22,7 @@ class BaseConfig(BaseModel):
 
             if field_type is bool:
                 command = click.option(
-                    f"--{field_name}/--no-{field_name}", help=description
+                    f"--{field_name}/--no-{field_name}", help=description, default=None
                 )(command)
             elif (
                 # Try avoid complex types such as lists and nested objects

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,7 @@ class TestBaseConfig:
 
         assert flag_option.opts == ["--flag"]
         assert flag_option.is_flag
+        assert flag_option.default is None
 
     def test_apply_click_options_uses_description_as_help(self):
         command = click.Command(name="Demo command")


### PR DESCRIPTION
This corrects a problem where not specifying a boolean argument forced it to be false and thus only allowed setting it to be true with a CLI argument.

The above sounds quite opaque so I'll demonstrate with an example:

If we have a config file for jailbreak guardrails with a `generate: true` and run:

```
uv run govuk_chat_evaluation jailbreak_guardrails
```

Then this overrides the `generate: true` to `generate: false` because of the default value of the CLI argument.

By setting this to a default of None, it only has an affect when the argument is specified. This is the behaviour we want for appropriately cascading options.