### PR TITLE
Use a file path argument for input_path

### DIFF
--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Literal, Self, cast
 
 import click
-from pydantic import Field, model_validator
+from pydantic import Field, FilePath, model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
@@ -18,7 +18,9 @@ class Config(BaseConfig):
         None,
         description="which provider to use for generating the data, openai or claude",
     )
-    input_path: str = Field(..., description="path to the data file used to evaluate")
+    input_path: FilePath = Field(
+        ..., description="path to the data file used to evaluate"
+    )
 
     @model_validator(mode="after")
     def check_provider_required(self) -> Self:
@@ -51,7 +53,7 @@ def main(**cli_args):
             config.input_path, cast(str, config.provider), output_dir
         )
     else:
-        evaluate_path = Path(config.input_path)
+        evaluate_path = config.input_path
 
     evaluate_and_output_results(output_dir, evaluate_path)
 

--- a/govuk_chat_evaluation/jailbreak_guardrails/generate.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/generate.py
@@ -13,7 +13,7 @@ class GenerateInput(BaseModel):
     expected_outcome: bool
 
 
-def generate_and_write_dataset(input_path: str, provider: str, output_dir: Path):
+def generate_and_write_dataset(input_path: Path, provider: str, output_dir: Path):
     models = jsonl_to_models(Path(input_path), GenerateInput)
     generated = generate_inputs_to_evaluation_results(provider, models)
     return write_generated_to_output(output_dir, generated)


### PR DESCRIPTION
This uses a more specific pydantic type of FilePath rather than a str. Using a FilePath has the advantages that pydantic validates that the file path is to a file that exists and it provides a Path type rather than a string type.