### PR TITLE
Allow running project as a module

### DIFF
--- a/govuk_chat_evaluation/__main__.py
+++ b/govuk_chat_evaluation/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()


### PR DESCRIPTION
This fills in code for the __main__.py file that I'd intended to have been in place when this file was committed but somehow missed it.

This allows the project to be run directly by pulling in the module (uv run -m govuk_chat_evaluation) and doesn't require using `pip install -e`. While the latter remains the expected way to run this app having this available is still useful should there be any issues with pip.