### PR TITLE
Reusability in config

### DIFF
--- a/govuk_chat_evaluation/config.py
+++ b/govuk_chat_evaluation/config.py
@@ -1,6 +1,6 @@
 from inspect import isclass
 from pathlib import Path
-from typing import get_origin, get_args, Optional, Type, TypeVar, Any
+from typing import get_origin, get_args, Optional, Type, TypeVar, Any, Self
 
 import click
 import yaml
@@ -10,6 +10,14 @@ GenericConfig = TypeVar("GenericConfig", bound="BaseConfig")
 
 
 class BaseConfig(BaseModel):
+    def _validate_fields_required_for_generate(self, *fields) -> Self:
+        if getattr(self, "generate", False):
+            for field in fields:
+                if hasattr(self, field) and getattr(self, field, None) is None:
+                    raise ValueError(f"{field} is required to generate data")
+
+        return self
+
     @classmethod
     def apply_click_options(cls, command):
         for field_name, field_info in cls.model_fields.items():

--- a/govuk_chat_evaluation/config.py
+++ b/govuk_chat_evaluation/config.py
@@ -1,15 +1,41 @@
 from inspect import isclass
 from pathlib import Path
-from typing import get_origin, get_args, Optional, Type, TypeVar, Any, Self
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    Optional,
+    Self,
+    Type,
+    TypeVar,
+    get_args,
+    get_origin,
+)
 
 import click
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, FilePath
 
 GenericConfig = TypeVar("GenericConfig", bound="BaseConfig")
 
 
 class BaseConfig(BaseModel):
+    class GenericFields:
+        """Commonly used fields across Configs"""
+
+        what = Annotated[str, Field(..., description="What is being evaluated")]
+        generate = Annotated[bool, Field(..., description="Whether to generate data")]
+        provider_openai_or_claude = Annotated[
+            Optional[Literal["openai", "claude"]],
+            Field(
+                None,
+                description="Which provider to use for generating the data, openai or claude",
+            ),
+        ]
+        input_path = Annotated[
+            FilePath, Field(..., description="Path to the data file used to evaluate")
+        ]
+
     def _validate_fields_required_for_generate(self, *fields) -> Self:
         if getattr(self, "generate", False):
             for field in fields:

--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Literal, Self, cast
+from typing import Self, cast
 
 import click
-from pydantic import Field, FilePath, model_validator
+from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
@@ -12,15 +12,10 @@ from .generate import generate_and_write_dataset
 
 
 class Config(BaseConfig):
-    what: str = Field(..., description="what is being evaluated")
-    generate: bool = Field(..., description="whether to generate data")
-    provider: Optional[Literal["openai", "claude"]] = Field(
-        None,
-        description="which provider to use for generating the data, openai or claude",
-    )
-    input_path: FilePath = Field(
-        ..., description="path to the data file used to evaluate"
-    )
+    what: BaseConfig.GenericFields.what
+    generate: BaseConfig.GenericFields.generate
+    provider: BaseConfig.GenericFields.provider_openai_or_claude
+    input_path: BaseConfig.GenericFields.input_path
 
     @model_validator(mode="after")
     def run_validatons(self) -> Self:

--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -23,10 +23,8 @@ class Config(BaseConfig):
     )
 
     @model_validator(mode="after")
-    def check_provider_required(self) -> Self:
-        if self.generate and self.provider is None:
-            raise ValueError("Provider is required to generate data")
-        return self
+    def run_validatons(self) -> Self:
+        return self._validate_fields_required_for_generate("provider")
 
 
 @click.command(name="jailbreak_guardrails")

--- a/tests/jailbreak_guardrails/test_cli.py
+++ b/tests/jailbreak_guardrails/test_cli.py
@@ -8,7 +8,7 @@ from govuk_chat_evaluation.jailbreak_guardrails.evaluate import EvaluationResult
 
 class TestConfig:
     def test_config_requires_provider_for_generate(self, mock_input_data):
-        with pytest.raises(ValueError, match="Provider is required to generate data"):
+        with pytest.raises(ValueError, match="provider is required to generate data"):
             Config(
                 what="Test",
                 generate=True,


### PR DESCRIPTION
Trello: https://trello.com/c/aCMTRtwW/2380-dev-and-data-science-work-together-to-write-evaluation-code-for-rag-questions

This adds a couple of approaches to reduce the duplicated code in Config objects. I added this as I was about to start a hefty copy and paste.

It's easiest to see the impacts of my changes in the Config class in govuk_chat_evaluation/jailbreak_guardrails/cli.py. The changes will seem premature in the context of this PR as there are no other classes using them. However I expect they will benefit a PR I'll open shortly and https://github.com/alphagov/govuk-chat-evaluation-prototype/pull/15