### PR TITLE
Output guardrails per-guardrail evaluation

### DIFF
--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -1,135 +1,23 @@
 from collections import Counter
 from functools import cached_property
 from pathlib import Path
-from typing import Any, List, cast
-from dataclasses import dataclass
+from typing import Any, cast
 
 import numpy as np
 from pydantic import BaseModel
 from sklearn.metrics import f1_score, precision_score, recall_score
 from tabulate import tabulate
-import re
-import logging
 
 from ..file_system import jsonl_to_models, write_csv_results
 import logging
-
-NUM_GUARDRAILS = 7
-
-
-@dataclass
-class GuardrailParseResult:
-    is_triggered: bool
-    valid_numbers: List[int]
-    warnings: List[str]
-
-    @staticmethod
-    def _process_guardrail_numbers(
-        numbers_str: str, num_guardrails: int
-    ) -> tuple[List[int], List[str]]:
-        """Parse, validate and deduplicate a comma-separated string of numbers.
-
-        Returns a tuple of (unique_valid_numbers, warnings).
-        """
-
-        warnings: list[str] = []
-
-        number_segments = [seg.strip() for seg in numbers_str.split(",") if seg.strip()]
-        original_numbers: list[int] = []
-
-        for segment in number_segments:
-            try:
-                original_numbers.append(int(segment))
-            except ValueError:
-                warnings.append(f"Non-integer value '{segment}' ignored.")
-
-        if not original_numbers:
-            warnings.append("Absence of valid guardrail numbers.")
-            return [], warnings
-
-        counts = Counter(original_numbers)
-        duplicates = sorted([num for num, c in counts.items() if c > 1])
-        if duplicates:
-            warnings.append(f"Removed duplicate numbers: {duplicates}.")
-
-        unique_numbers = sorted(set(original_numbers))
-
-        valid_numbers = [n for n in unique_numbers if 1 <= n <= num_guardrails]
-        out_of_range = [n for n in unique_numbers if n not in valid_numbers]
-        if out_of_range:
-            warnings.append(
-                f"Removed numbers outside the valid range [1, {num_guardrails}]: {out_of_range}."
-            )
-
-        if not valid_numbers:
-            warnings.append(
-                "Resulted in no valid guardrails after filtering/deduplication."
-            )
-
-        return valid_numbers, warnings
-
-    @classmethod
-    def parse(cls, exact_string: str, num_guardrails: int) -> "GuardrailParseResult":
-        """Parses the exact guardrail result string.
-
-        Returns a GuardrailParseResult object containing the trigger status,
-        a list of valid, unique guardrail numbers, and any warnings.
-        """
-        # Regex pattern requiring either:
-        #   True  | "<numbers, spaces, commas>"  OR
-        #   False | None
-        pattern = r"^\s*(True|False)\s*\|\s*(?:\"([0-9,\s]*)\"|(None))\s*$"
-        match = re.match(pattern, exact_string)
-
-        warnings: list[str] = []
-
-        if not match:
-            warnings.append(
-                "String does not match expected format 'True | \"1,2\"' or 'False | None'."
-            )
-            return cls(False, [], warnings)
-
-        triggered = match.group(1) == "True"
-        guardrails_str = match.group(2)  # Comma-separated numbers, if present
-        none_str = match.group(3)  # The literal string "None", if present
-
-        if triggered:
-            if guardrails_str is None:
-                warnings.append("Triggered == True but no guardrail numbers supplied.")
-                return cls(is_triggered=False, valid_numbers=[], warnings=warnings)
-
-            valid_numbers, num_warnings = cls._process_guardrail_numbers(
-                guardrails_str, num_guardrails
-            )
-            warnings.extend(num_warnings)
-            return cls(
-                is_triggered=True, valid_numbers=valid_numbers, warnings=warnings
-            )
-
-        if none_str != "None":
-            warnings.append("Triggered == False but expected literal 'None'.")
-        return cls(False, [], warnings)
-
-    def to_vector(self, num_guardrails: int) -> List[int]:
-        """Return a binary vector indicating which guardrails are triggered.
-
-        Each index in the returned list corresponds to a guardrail (1-indexed),
-        holding 1 if that guardrail was triggered for the answer and 0
-        otherwise.
-        """
-        if not self.is_triggered:
-            return [0] * num_guardrails
-
-        guardrail_set = set(self.valid_numbers)
-        return [1 if i + 1 in guardrail_set else 0 for i in range(num_guardrails)]
 
 
 class EvaluationResult(BaseModel):
     question: str
     expected_triggered: bool
     actual_triggered: bool
-    expected_exact: str
-    actual_exact: str
+    expected_guardrails: dict[str, bool]
+    actual_guardrails: dict[str, bool]
 
     @property
     def classification_triggered(self) -> str:
@@ -143,93 +31,85 @@ class EvaluationResult(BaseModel):
             case (True, False):
                 return "false_negative"
 
-    @cached_property
-    def _parsed_expected(self) -> GuardrailParseResult:
-        return GuardrailParseResult.parse(self.expected_exact, NUM_GUARDRAILS)
-
-    @cached_property
-    def _parsed_actual(self) -> GuardrailParseResult:
-        return GuardrailParseResult.parse(self.actual_exact, NUM_GUARDRAILS)
-
-    @property
-    def expected_exact_triggered(self) -> List[int]:
-        return self._parsed_expected.to_vector(NUM_GUARDRAILS)
-
-    @property
-    def actual_exact_triggered(self) -> List[int]:
-        return self._parsed_actual.to_vector(NUM_GUARDRAILS)
-
-    @property
-    def warnings(self) -> List[str]:
-        return self._parsed_expected.warnings + self._parsed_actual.warnings
-
     def for_csv(self) -> dict[str, Any]:
         return {**self.model_dump(), "classification": self.classification_triggered}
 
 
 class AggregateResults:
-    def __init__(self, evaluation_results: List[EvaluationResult]):
+    def __init__(self, evaluation_results: list[EvaluationResult]):
         self.evaluation_results = evaluation_results
         counter = Counter(
-            evaluation_result.classification_triggered
-            for evaluation_result in evaluation_results
+            result.classification_triggered for result in evaluation_results
         )
         self.true_positive = counter.get("true_positive", 0)
         self.true_negative = counter.get("true_negative", 0)
         self.false_positive = counter.get("false_positive", 0)
         self.false_negative = counter.get("false_negative", 0)
 
+        guardrail_set = {
+            name
+            for result in evaluation_results
+            for name in list(result.expected_guardrails.keys())
+            + list(result.actual_guardrails.keys())
+        }
+        self.guardrail_names: list[str] = sorted(guardrail_set)
+
     @cached_property
-    def _expected_actual_lists(self) -> tuple[List[int], List[int]]:
-        expected, actual = zip(
-            *(
-                (
-                    int(evaluation_result.expected_triggered),
-                    int(evaluation_result.actual_triggered),
-                )
-                for evaluation_result in self.evaluation_results
+    def _expected_actual_triggered_lists(self) -> tuple[list[int], list[int]]:
+        pairs_list = [
+            (
+                int(evaluation_result.expected_triggered),
+                int(evaluation_result.actual_triggered),
             )
-        )
+            for evaluation_result in self.evaluation_results
+        ]
+        expected, actual = zip(*pairs_list)
         return list(expected), list(actual)
 
     @cached_property
-    def _expected_actual_vectors(self) -> tuple[List[List[int]], List[List[int]]]:
+    def _expected_actual_guardrails_vectors(
+        self,
+    ) -> tuple[list[list[int]], list[list[int]]]:
         """Generates lists of expected and actual binary vectors for per-guardrail evaluation."""
-        if not self.evaluation_results:
-            return [], []
+
+        def to_vector(d: dict[str, bool]) -> list[int]:
+            return [int(d.get(name, False)) for name in self.guardrail_names]
 
         expected_vectors = [
-            result.expected_exact_triggered for result in self.evaluation_results
+            to_vector(result.expected_guardrails) for result in self.evaluation_results
         ]
         actual_vectors = [
-            result.actual_exact_triggered for result in self.evaluation_results
+            to_vector(result.actual_guardrails) for result in self.evaluation_results
         ]
         return expected_vectors, actual_vectors
 
-    def _metric_any(self, metric_function):
-        return metric_function(*self._expected_actual_lists, zero_division=np.nan)  # type: ignore
+    def _triggered_metric(self, metric_function):
+        expected, actual = self._expected_actual_triggered_lists
+        return metric_function(expected, actual, zero_division=np.nan)  # type: ignore
 
     def _metric_per_guardrail(self, metric_function):
-        expected_vectors, actual_vectors = self._expected_actual_vectors
-        if not expected_vectors:
-            return [np.nan] * NUM_GUARDRAILS
+        expected_vectors, actual_vectors = self._expected_actual_guardrails_vectors
+
         return metric_function(
-            expected_vectors, actual_vectors, average=None, zero_division=np.nan
+            expected_vectors,
+            actual_vectors,
+            average=None,
+            zero_division=np.nan,
         ).tolist()  # type: ignore
 
     def precision(self) -> float:
-        return cast(float, self._metric_any(precision_score))
+        return cast(float, self._triggered_metric(precision_score))
 
     def recall(self) -> float:
-        return cast(float, self._metric_any(recall_score))
+        return cast(float, self._triggered_metric(recall_score))
 
-    def precision_per_guardrail(self) -> List[float]:
+    def precision_per_guardrail(self) -> list[float]:
         return self._metric_per_guardrail(precision_score)
 
-    def recall_per_guardrail(self) -> List[float]:
+    def recall_per_guardrail(self) -> list[float]:
         return self._metric_per_guardrail(recall_score)
 
-    def f1_per_guardrail(self) -> List[float]:
+    def f1_per_guardrail(self) -> list[float]:
         return self._metric_per_guardrail(f1_score)
 
     def to_dict(self) -> dict[str, Any]:
@@ -243,16 +123,14 @@ class AggregateResults:
             "Any-triggered False negatives": self.false_negative,
         }
 
-        # Per-guardrail metrics
         precisions = self.precision_per_guardrail()
         recalls = self.recall_per_guardrail()
         f1s = self.f1_per_guardrail()
 
-        for i in range(NUM_GUARDRAILS):
-            guardrail_num = i + 1
-            base_metrics[f"Precision G{guardrail_num}"] = precisions[i]
-            base_metrics[f"Recall G{guardrail_num}"] = recalls[i]
-            base_metrics[f"F1 G{guardrail_num}"] = f1s[i]
+        for i, name in enumerate(self.guardrail_names):
+            base_metrics[f"Precision [{name}]"] = precisions[i]
+            base_metrics[f"Recall [{name}]"] = recalls[i]
+            base_metrics[f"F1 [{name}]"] = f1s[i]
 
         return base_metrics
 
@@ -266,14 +144,6 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     if not models:
         logging.error("\nThere is no data to evaluate")
         return
-
-    logging.info("\nEvaluation complete")
-    for model in models:
-        for warning in model.warnings:
-            logging.warning(
-                f'{warning}  Parsing actual_exact="{model.actual_exact}" '
-                f'for question="{model.question}".'
-            )
 
     write_csv_results(output_dir, [model.for_csv() for model in models])
 

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -1,7 +1,7 @@
 from collections import Counter
 from functools import cached_property
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, cast
 from dataclasses import dataclass
 
 import numpy as np
@@ -18,10 +18,110 @@ NUM_GUARDRAILS = 7
 
 
 @dataclass
-class _GuardrailParseResult:
+class GuardrailParseResult:
     is_triggered: bool
-    valid_numbers: List[int]  # Unique, valid guardrail numbers
-    warnings: List[str]  # Warnings generated during parsing
+    valid_numbers: List[int]
+    warnings: List[str]
+
+    @staticmethod
+    def _process_guardrail_numbers(
+        numbers_str: str, num_guardrails: int
+    ) -> tuple[List[int], List[str]]:
+        """Parse, validate and deduplicate a comma-separated string of numbers.
+
+        Returns a tuple of (unique_valid_numbers, warnings).
+        """
+
+        warnings: list[str] = []
+
+        number_segments = [seg.strip() for seg in numbers_str.split(",") if seg.strip()]
+        original_numbers: list[int] = []
+
+        for segment in number_segments:
+            try:
+                original_numbers.append(int(segment))
+            except ValueError:
+                warnings.append(f"Non-integer value '{segment}' ignored.")
+
+        if not original_numbers:
+            warnings.append("Absence of valid guardrail numbers.")
+            return [], warnings
+
+        counts = Counter(original_numbers)
+        duplicates = sorted([num for num, c in counts.items() if c > 1])
+        if duplicates:
+            warnings.append(f"Removed duplicate numbers: {duplicates}.")
+
+        unique_numbers = sorted(set(original_numbers))
+
+        valid_numbers = [n for n in unique_numbers if 1 <= n <= num_guardrails]
+        out_of_range = [n for n in unique_numbers if n not in valid_numbers]
+        if out_of_range:
+            warnings.append(
+                f"Removed numbers outside the valid range [1, {num_guardrails}]: {out_of_range}."
+            )
+
+        if not valid_numbers:
+            warnings.append(
+                "Resulted in no valid guardrails after filtering/deduplication."
+            )
+
+        return valid_numbers, warnings
+
+    @classmethod
+    def parse(cls, exact_string: str, num_guardrails: int) -> "GuardrailParseResult":
+        """Parses the exact guardrail result string.
+
+        Returns a GuardrailParseResult object containing the trigger status,
+        a list of valid, unique guardrail numbers, and any warnings.
+        """
+        # Regex pattern requiring either:
+        #   True  | "<numbers, spaces, commas>"  OR
+        #   False | None
+        pattern = r"^\s*(True|False)\s*\|\s*(?:\"([0-9,\s]*)\"|(None))\s*$"
+        match = re.match(pattern, exact_string)
+
+        warnings: list[str] = []
+
+        if not match:
+            warnings.append(
+                "String does not match expected format 'True | \"1,2\"' or 'False | None'."
+            )
+            return cls(False, [], warnings)
+
+        triggered = match.group(1) == "True"
+        guardrails_str = match.group(2)  # Comma-separated numbers, if present
+        none_str = match.group(3)  # The literal string "None", if present
+
+        if triggered:
+            if guardrails_str is None:
+                warnings.append("Triggered == True but no guardrail numbers supplied.")
+                return cls(is_triggered=False, valid_numbers=[], warnings=warnings)
+
+            valid_numbers, num_warnings = cls._process_guardrail_numbers(
+                guardrails_str, num_guardrails
+            )
+            warnings.extend(num_warnings)
+            return cls(
+                is_triggered=True, valid_numbers=valid_numbers, warnings=warnings
+            )
+
+        if none_str != "None":
+            warnings.append("Triggered == False but expected literal 'None'.")
+        return cls(False, [], warnings)
+
+    def to_vector(self, num_guardrails: int) -> List[int]:
+        """Return a binary vector indicating which guardrails are triggered.
+
+        Each index in the returned list corresponds to a guardrail (1-indexed),
+        holding 1 if that guardrail was triggered for the answer and 0
+        otherwise.
+        """
+        if not self.is_triggered:
+            return [0] * num_guardrails
+
+        guardrail_set = set(self.valid_numbers)
+        return [1 if i + 1 in guardrail_set else 0 for i in range(num_guardrails)]
 
 
 class EvaluationResult(BaseModel):
@@ -43,173 +143,25 @@ class EvaluationResult(BaseModel):
             case (True, False):
                 return "false_negative"
 
-    @property
-    def expected_exact_triggered(self) -> List[int] | None:
-        """Parses `expected_exact` and returns a binary vector if triggered."""
-        try:
-            result = self.parse_exact_string(self.expected_exact, NUM_GUARDRAILS)
+    @cached_property
+    def _parsed_expected(self) -> GuardrailParseResult:
+        return GuardrailParseResult.parse(self.expected_exact, NUM_GUARDRAILS)
 
-            for warning_msg in result.warnings:
-                logging.warning(
-                    f'{warning_msg} Parsing expected_exact="{self.expected_exact}" '
-                    f'for question="{self.question}".'
-                )
-
-            if result.is_triggered:
-                return self._guardrail_list_to_vec(result.valid_numbers, NUM_GUARDRAILS)
-            else:
-                return None
-        except ValueError as e:
-            logging.warning(
-                f'Failed to parse expected_exact="{self.expected_exact}" '
-                + f'for question="{self.question}": {e}. Treating as None.'
-            )
-            return None
+    @cached_property
+    def _parsed_actual(self) -> GuardrailParseResult:
+        return GuardrailParseResult.parse(self.actual_exact, NUM_GUARDRAILS)
 
     @property
-    def actual_exact_triggered(self) -> List[int] | None:
-        """Parses `actual_exact` and returns a binary vector if triggered."""
-        try:
-            result = self.parse_exact_string(self.actual_exact, NUM_GUARDRAILS)
+    def expected_exact_triggered(self) -> List[int]:
+        return self._parsed_expected.to_vector(NUM_GUARDRAILS)
 
-            for warning_msg in result.warnings:
-                logging.warning(
-                    f'{warning_msg} Parsing actual_exact="{self.actual_exact}" '
-                    f'for question="{self.question}".'
-                )
+    @property
+    def actual_exact_triggered(self) -> List[int]:
+        return self._parsed_actual.to_vector(NUM_GUARDRAILS)
 
-            if result.is_triggered:
-                return self._guardrail_list_to_vec(result.valid_numbers, NUM_GUARDRAILS)
-            else:
-                return None
-        except ValueError as e:
-            logging.warning(
-                f'Failed to parse actual_exact="{self.actual_exact}" '
-                + f'for question="{self.question}": {e}. Treating as None.'
-            )
-            return None
-
-    @staticmethod
-    def _guardrail_list_to_vec(
-        guardrail_numbers: List[int], num_guardrails: int
-    ) -> List[int]:
-        """Returns a binary vector of triggered guardrails from a list of numbers.
-
-        Each element of the vector represents whether the corresponding
-        guardrail has been triggered. For example:
-
-        [1, 3, 5] -> [1, 0, 1, 0, 1, 0, 0] (assuming num_guardrails=7)
-        [1] -> [1, 0, 0, 0, 0, 0, 0]
-        [6, 7] -> [0, 0, 0, 0, 0, 1, 1]
-        [] -> [0, 0, 0, 0, 0, 0, 0]
-        """
-        if not guardrail_numbers:
-            return [0] * num_guardrails
-
-        guardrail_set = set(guardrail_numbers)
-        return [1 if i + 1 in guardrail_set else 0 for i in range(num_guardrails)]
-
-    @staticmethod
-    def _process_guardrail_numbers(
-        exact_string_context: str, numbers_str: str, num_guardrails: int
-    ) -> tuple[List[int], List[str]]:
-        """Parses, validates, filters, and deduplicates guardrail numbers."""
-        warnings = []
-        original_guardrail_numbers = []
-
-        number_segments = numbers_str.split(",")
-        for segment in number_segments:
-            stripped_segment = segment.strip()
-            try:
-                original_guardrail_numbers.append(int(stripped_segment))
-            except ValueError as e:
-                raise ValueError(
-                    f"Guardrail string '{exact_string_context}' contains non-integer value "
-                    f"'{stripped_segment}' in the comma-separated list: {e}"
-                ) from e
-
-        if not original_guardrail_numbers:
-            return [], []
-
-        original_set = set(original_guardrail_numbers)
-        valid_range_set = {num for num in original_set if 1 <= num <= num_guardrails}
-        out_of_range_set = original_set - valid_range_set
-
-        valid_range_list = [
-            num for num in original_guardrail_numbers if 1 <= num <= num_guardrails
-        ]
-        if len(valid_range_list) != len(valid_range_set):
-            counts = Counter(valid_range_list)
-            duplicates = sorted([num for num, count in counts.items() if count > 1])
-            warnings.append(f"Removed duplicate numbers: {duplicates}.")
-
-        if out_of_range_set:
-            warnings.append(
-                f"Removed numbers outside the valid range [1, {num_guardrails}]: {sorted(list(out_of_range_set))}."
-            )
-
-        unique_valid_numbers = sorted(list(valid_range_set))
-
-        if not unique_valid_numbers and original_guardrail_numbers:
-            warnings.append(
-                "Resulted in no valid guardrails after filtering/deduplication."
-            )
-
-        return unique_valid_numbers, warnings
-
-    @staticmethod
-    def parse_exact_string(
-        exact_string: str, num_guardrails: int
-    ) -> _GuardrailParseResult:
-        """Parses the exact guardrail result string.
-
-        Returns:
-            A _GuardrailParseResult object containing the trigger status,
-            a list of valid, unique guardrail numbers, and any warnings.
-        """
-        pattern = r"^(True|False)\s*\|\s*(?:\"(.*)\"|(None))$"
-        match = re.match(pattern, exact_string)
-
-        if not match:
-            raise ValueError(
-                f"Guardrail string '{exact_string}' does not match expected format "
-                f"'True | \"<comma-separated numbers>\"' or 'False | None'."
-            )
-
-        triggered_str = match.group(1)
-        guardrails_str = match.group(2)  # Comma-separated numbers, if present
-        none_str = match.group(3)  # The literal string "None", if present
-
-        if triggered_str == "True":
-            if guardrails_str is None:
-                raise ValueError(
-                    f"Guardrail string '{exact_string}' reports being triggered (True), but is not "
-                    f"followed by quoted comma-separated numbers (e.g., 'True | \"1,2\"')."
-                )
-
-            if guardrails_str == "":
-                raise ValueError(
-                    f"Guardrail string '{exact_string}' has 'True' but guardrails string "
-                    f"is empty. Expected comma-separated numbers."
-                )
-
-            valid_numbers, warnings = EvaluationResult._process_guardrail_numbers(
-                exact_string, guardrails_str, num_guardrails
-            )
-            return _GuardrailParseResult(
-                is_triggered=True, valid_numbers=valid_numbers, warnings=warnings
-            )
-
-        else:  # triggered_str == "False"
-            if none_str != "None" or guardrails_str is not None:
-                raise ValueError(
-                    f"Guardrail string '{exact_string}' starts with 'False' but is not "
-                    f"followed by 'None'. Expected format 'False | None'."
-                )
-            # Return non-triggered result with empty numbers/warnings
-            return _GuardrailParseResult(
-                is_triggered=False, valid_numbers=[], warnings=[]
-            )
+    @property
+    def warnings(self) -> List[str]:
+        return self._parsed_expected.warnings + self._parsed_actual.warnings
 
     def for_csv(self) -> dict[str, Any]:
         return {**self.model_dump(), "classification": self.classification_triggered}
@@ -229,90 +181,56 @@ class AggregateResults:
 
     @cached_property
     def _expected_actual_lists(self) -> tuple[List[int], List[int]]:
-        pairs_list = [
-            (
-                int(evaluation_result.expected_triggered),
-                int(evaluation_result.actual_triggered),
+        expected, actual = zip(
+            *(
+                (
+                    int(evaluation_result.expected_triggered),
+                    int(evaluation_result.actual_triggered),
+                )
+                for evaluation_result in self.evaluation_results
             )
-            for evaluation_result in self.evaluation_results
-        ]
-        expected, actual = zip(*pairs_list)
+        )
         return list(expected), list(actual)
 
     @cached_property
     def _expected_actual_vectors(self) -> tuple[List[List[int]], List[List[int]]]:
-        """
-        Generates lists of expected and actual binary vectors for per-guardrail evaluation.
-
-        Vectors represent triggered guardrails. If a result indicates no trigger
-        (expected_triggered or actual_triggered is False), a zero vector is used.
-        """
-        expected_vectors = []
-        actual_vectors = []
-        zero_vector = [0] * NUM_GUARDRAILS
-
-        for result in self.evaluation_results:
-            expected_vec = result.expected_exact_triggered
-            actual_vec = result.actual_exact_triggered
-
-            expected_vectors.append(
-                expected_vec if expected_vec is not None else zero_vector
-            )
-            actual_vectors.append(actual_vec if actual_vec is not None else zero_vector)
-
-        # Handle the edge case where there are no results to evaluate
-        if not expected_vectors:
+        """Generates lists of expected and actual binary vectors for per-guardrail evaluation."""
+        if not self.evaluation_results:
             return [], []
 
+        expected_vectors = [
+            result.expected_exact_triggered for result in self.evaluation_results
+        ]
+        actual_vectors = [
+            result.actual_exact_triggered for result in self.evaluation_results
+        ]
         return expected_vectors, actual_vectors
 
+    def _metric_any(self, metric_function):
+        return metric_function(*self._expected_actual_lists, zero_division=np.nan)  # type: ignore
+
+    def _metric_per_guardrail(self, metric_function):
+        expected_vectors, actual_vectors = self._expected_actual_vectors
+        if not expected_vectors:
+            return [np.nan] * NUM_GUARDRAILS
+        return metric_function(
+            expected_vectors, actual_vectors, average=None, zero_division=np.nan
+        ).tolist()  # type: ignore
+
     def precision(self) -> float:
-        return precision_score(
-            *self._expected_actual_lists,
-            zero_division=np.nan,  # type: ignore
-        )
+        return cast(float, self._metric_any(precision_score))
 
     def recall(self) -> float:
-        return recall_score(
-            *self._expected_actual_lists,
-            zero_division=np.nan,  # type: ignore
-        )
+        return cast(float, self._metric_any(recall_score))
 
     def precision_per_guardrail(self) -> List[float]:
-        """Calculates precision for each guardrail individually."""
-        expected_vectors, actual_vectors = self._expected_actual_vectors
-        if not expected_vectors:  # Avoid calling score with empty lists
-            return [np.nan] * NUM_GUARDRAILS
-        return precision_score(
-            expected_vectors,
-            actual_vectors,
-            average=None,  # type: ignore
-            zero_division=0,  # type: ignore
-        ).tolist()  # type: ignore
+        return self._metric_per_guardrail(precision_score)
 
     def recall_per_guardrail(self) -> List[float]:
-        """Calculates recall for each guardrail individually."""
-        expected_vectors, actual_vectors = self._expected_actual_vectors
-        if not expected_vectors:
-            return [np.nan] * NUM_GUARDRAILS
-        return recall_score(
-            expected_vectors,
-            actual_vectors,
-            average=None,  # type: ignore
-            zero_division=0,  # type: ignore
-        ).tolist()  # type: ignore
+        return self._metric_per_guardrail(recall_score)
 
     def f1_per_guardrail(self) -> List[float]:
-        """Calculates F1 score for each guardrail individually."""
-        expected_vectors, actual_vectors = self._expected_actual_vectors
-        if not expected_vectors:
-            return [np.nan] * NUM_GUARDRAILS
-        return f1_score(
-            expected_vectors,
-            actual_vectors,
-            average=None,  # type: ignore
-            zero_division=0,  # type: ignore
-        ).tolist()  # type: ignore
+        return self._metric_per_guardrail(f1_score)
 
     def to_dict(self) -> dict[str, Any]:
         base_metrics = {
@@ -350,10 +268,16 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
         return
 
     logging.info("\nEvaluation complete")
+    for model in models:
+        for warning in model.warnings:
+            logging.warning(
+                f'{warning}  Parsing actual_exact="{model.actual_exact}" '
+                f'for question="{model.question}".'
+            )
+
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
     aggregate_results = AggregateResults(models)
-
     write_csv_results(
         output_dir,
         aggregate_results.for_csv(),

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -7,6 +7,7 @@ import numpy as np
 from pydantic import BaseModel
 from sklearn.metrics import precision_score, recall_score
 from tabulate import tabulate
+import re
 
 from ..file_system import jsonl_to_models, write_csv_results
 import logging
@@ -30,6 +31,110 @@ class EvaluationResult(BaseModel):
                 return "false_positive"
             case (True, False):
                 return "false_negative"
+
+    @property
+    def expected_exact_triggered(self) -> List[int] | None:
+        """Parses `expected_exact` and returns a binary vector if triggered"""
+        triggered, guardrails_str = self.parse_exact_string(self.expected_exact, 7)
+        if triggered:
+            return self.guardrail_str_to_vec(guardrails_str, 7)
+        else:
+            return None
+
+    @property
+    def actual_exact_triggered(self) -> List[int] | None:
+        """Parses `actual_exact` and returns a binary vector if triggered"""
+        triggered, guardrails_str = self.parse_exact_string(self.actual_exact, 7)
+        if triggered:
+            return self.guardrail_str_to_vec(guardrails_str, 7)
+        else:
+            return None
+
+    @staticmethod
+    def guardrail_str_to_vec(guardrails_str: str, num_guardrails: int) -> List[int]:
+        """Returns a binary vector of triggered guardrails
+
+        Each element of the vector represents whether the corresponding
+        guardrail has been triggered. For example:
+
+        "1, 3, 5" -> [1, 0, 1, 0, 0, 0, 0]
+        "1" -> [1, 0, 0, 0, 0, 0, 0]
+        "6, 7" -> [0, 0, 0, 0, 0, 1, 1]
+        """
+        if not guardrails_str.strip():
+            return [0] * num_guardrails
+
+        guardrail_set = {
+            int(guardrail.strip()) for guardrail in guardrails_str.split(",")
+        }
+        return [1 if i + 1 in guardrail_set else 0 for i in range(num_guardrails)]
+
+    @staticmethod
+    def parse_exact_string(exact_string: str, num_guardrails: int) -> tuple[bool, str]:
+        """Parses the exact guardrail result string for guardrail triggers
+
+        Returns:
+            A tuple containing:
+                - A boolean indicating if any guardrail was triggered.
+                - A string of comma-separated guardrail numbers if triggered,
+                  otherwise the string "None".
+        """
+        # Pattern distinguishes between quoted comma-separated numbers and the literal None
+        pattern = r"^(True|False)\s*\|\s*(?:\"(.*)\"|(None))$"
+        match = re.match(pattern, exact_string)
+
+        if not match:
+            raise ValueError(
+                f"Guardrail string '{exact_string}' does not match expected format "
+                f"'True | \"<comma-separated numbers>\"' or 'False | None'."
+            )
+
+        triggered_str = match.group(1)
+        guardrails_str = match.group(2)  # comma-separated guardrail numbers, if present
+        none_str = match.group(3)  # The literal string "None", if present
+
+        if triggered_str == "True":
+            if guardrails_str is None:
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' reports being triggered, but is not "
+                    f"followed by quoted comma-separated numbers (e.g., 'True | \"1,2\"')."
+                )
+
+            if not guardrails_str.strip():
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' has 'True' but contains an empty "
+                    f"quoted string. Expected comma-separated numbers."
+                )
+
+            try:
+                guardrail_numbers = [int(num) for num in guardrails_str.split(",")]
+            except ValueError as e:
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' contains non-integer value "
+                    f"in the comma-separated list: {e}"
+                ) from e
+
+            if not all(1 <= num <= num_guardrails for num in guardrail_numbers):
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' contains numbers outside the "
+                    f"valid range [1, {num_guardrails}]."
+                )
+
+            if len(guardrail_numbers) != len(set(guardrail_numbers)):
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' contains duplicate guardrail numbers."
+                )
+
+            return True, guardrails_str
+
+        else:  # triggered_str == "False"
+            if none_str != "None" or guardrails_str is not None:
+                raise ValueError(
+                    f"Guardrail string '{exact_string}' starts with 'False' but is not "
+                    f"followed by 'None'. Expected format 'False | None'."
+                )
+
+            return False, "None"
 
     def for_csv(self) -> dict[str, Any]:
         return {**self.model_dump(), "classification": self.classification_triggered}

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -14,12 +14,14 @@ import logging
 
 class EvaluationResult(BaseModel):
     question: str
-    expected_outcome: bool
-    actual_outcome: bool
+    expected_triggered: bool
+    actual_triggered: bool
+    expected_exact: str
+    actual_exact: str
 
     @property
-    def classification(self) -> str:
-        match (self.expected_outcome, self.actual_outcome):
+    def classification_triggered(self) -> str:
+        match (self.expected_triggered, self.actual_triggered):
             case (True, True):
                 return "true_positive"
             case (False, False):
@@ -30,14 +32,15 @@ class EvaluationResult(BaseModel):
                 return "false_negative"
 
     def for_csv(self) -> dict[str, Any]:
-        return {**self.model_dump(), "classification": self.classification}
+        return {**self.model_dump(), "classification": self.classification_triggered}
 
 
 class AggregateResults:
     def __init__(self, evaluation_results: List[EvaluationResult]):
         self.evaluation_results = evaluation_results
         counter = Counter(
-            evaluation_result.classification for evaluation_result in evaluation_results
+            evaluation_result.classification_triggered
+            for evaluation_result in evaluation_results
         )
         self.true_positive = counter.get("true_positive", 0)
         self.true_negative = counter.get("true_negative", 0)
@@ -48,8 +51,8 @@ class AggregateResults:
     def _expected_actual_lists(self) -> tuple[List[int], List[int]]:
         pairs_list = [
             (
-                int(evaluation_result.expected_outcome),
-                int(evaluation_result.actual_outcome),
+                int(evaluation_result.expected_triggered),
+                int(evaluation_result.actual_triggered),
             )
             for evaluation_result in self.evaluation_results
         ]

--- a/govuk_chat_evaluation/output_guardrails/generate.py
+++ b/govuk_chat_evaluation/output_guardrails/generate.py
@@ -10,7 +10,8 @@ from ..file_system import jsonl_to_models, write_generated_to_output
 
 class GenerateInput(BaseModel):
     question: str
-    expected_outcome: bool
+    expected_triggered: bool
+    expected_exact: str
 
 
 def generate_and_write_dataset(
@@ -36,8 +37,10 @@ def generate_inputs_to_evaluation_results(
 
         return EvaluationResult(
             question=input.question,
-            expected_outcome=input.expected_outcome,
-            actual_outcome=result["triggered"],
+            expected_triggered=input.expected_triggered,
+            actual_triggered=result["triggered"],
+            expected_exact=input.expected_exact,
+            actual_exact=result["llm_guardrail_result"],
         )
 
     return asyncio.run(

--- a/govuk_chat_evaluation/output_guardrails/generate.py
+++ b/govuk_chat_evaluation/output_guardrails/generate.py
@@ -11,7 +11,7 @@ from ..file_system import jsonl_to_models, write_generated_to_output
 class GenerateInput(BaseModel):
     question: str
     expected_triggered: bool
-    expected_exact: str
+    expected_guardrails: dict[str, bool]
 
 
 def generate_and_write_dataset(
@@ -39,8 +39,8 @@ def generate_inputs_to_evaluation_results(
             question=input.question,
             expected_triggered=input.expected_triggered,
             actual_triggered=result["triggered"],
-            expected_exact=input.expected_exact,
-            actual_exact=result["llm_guardrail_result"],
+            expected_guardrails=input.expected_guardrails,
+            actual_guardrails=result["guardrails"],
         )
 
     return asyncio.run(

--- a/tests/output_guardrails/conftest.py
+++ b/tests/output_guardrails/conftest.py
@@ -10,15 +10,15 @@ def mock_input_data(mock_project_root):
             "question": "Question 1",
             "expected_triggered": True,
             "actual_triggered": True,
-            "expected_exact": 'True | "1, 3"',
-            "actual_exact": 'True | "1, 3"',
+            "expected_guardrails": {"appropriate_language": True, "political": True},
+            "actual_guardrails": {"appropriate_language": True, "political": True},
         },
         {
             "question": "Question 2",
             "expected_triggered": False,
             "actual_triggered": True,
-            "expected_exact": "False | None",
-            "actual_exact": 'True | "1, 3"',
+            "expected_guardrails": {"appropriate_language": False},
+            "actual_guardrails": {"appropriate_language": True, "political": True},
         },
     ]
 

--- a/tests/output_guardrails/conftest.py
+++ b/tests/output_guardrails/conftest.py
@@ -8,13 +8,17 @@ def mock_input_data(mock_project_root):
     data = [
         {
             "question": "Question 1",
-            "expected_outcome": True,
-            "actual_outcome": True,
+            "expected_triggered": True,
+            "actual_triggered": True,
+            "expected_exact": 'True | "1, 3"',
+            "actual_exact": 'True | "1, 3"',
         },
         {
             "question": "Question 2",
-            "expected_outcome": False,
-            "actual_outcome": True,
+            "expected_triggered": False,
+            "actual_triggered": True,
+            "expected_exact": "False | None",
+            "actual_exact": 'True | "1, 3"',
         },
     ]
 

--- a/tests/output_guardrails/test_cli.py
+++ b/tests/output_guardrails/test_cli.py
@@ -64,15 +64,15 @@ def mock_data_generation(mocker):
             question="Question",
             expected_triggered=True,
             actual_triggered=True,
-            expected_exact="True | None",
-            actual_exact="True | None",
+            expected_guardrails={"appropriate_language": True},
+            actual_guardrails={"appropriate_language": True},
         ),
         EvaluationResult(
             question="Question",
             expected_triggered=False,
             actual_triggered=False,
-            expected_exact="False | None",
-            actual_exact="False | None",
+            expected_guardrails={"appropriate_language": False},
+            actual_guardrails={"appropriate_language": False},
         ),
     ]
 

--- a/tests/output_guardrails/test_cli.py
+++ b/tests/output_guardrails/test_cli.py
@@ -62,13 +62,17 @@ def mock_data_generation(mocker):
     return_value = [
         EvaluationResult(
             question="Question",
-            expected_outcome=True,
-            actual_outcome=True,
+            expected_triggered=True,
+            actual_triggered=True,
+            expected_exact="True | None",
+            actual_exact="True | None",
         ),
         EvaluationResult(
             question="Question",
-            expected_outcome=False,
-            actual_outcome=False,
+            expected_triggered=False,
+            actual_triggered=False,
+            expected_exact="False | None",
+            actual_exact="False | None",
         ),
     ]
 

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -11,8 +11,53 @@ from govuk_chat_evaluation.output_guardrails.evaluate import (
     AggregateResults,
     EvaluationResult,
     evaluate_and_output_results,
-    _GuardrailParseResult,
+    GuardrailParseResult,
+    NUM_GUARDRAILS,
 )
+
+
+@pytest.fixture
+def result_true_positive() -> EvaluationResult:  # type: ignore
+    return EvaluationResult(
+        question="TP",
+        expected_triggered=True,
+        actual_triggered=True,
+        expected_exact='True | "1, 3"',
+        actual_exact='True | "1, 3"',
+    )
+
+
+@pytest.fixture
+def result_false_positive() -> EvaluationResult:  # type: ignore
+    return EvaluationResult(
+        question="FP",
+        expected_triggered=False,
+        actual_triggered=True,
+        expected_exact="False | None",
+        actual_exact='True | "1, 3"',
+    )
+
+
+@pytest.fixture
+def result_false_negative() -> EvaluationResult:  # type: ignore
+    return EvaluationResult(
+        question="FN",
+        expected_triggered=True,
+        actual_triggered=False,
+        expected_exact='True | "1, 3"',
+        actual_exact="False | None",
+    )
+
+
+@pytest.fixture
+def result_true_negative() -> EvaluationResult:  # type: ignore
+    return EvaluationResult(
+        question="TN",
+        expected_triggered=False,
+        actual_triggered=False,
+        expected_exact="False | None",
+        actual_exact="False | None",
+    )
 
 
 class TestEvaluationResult:
@@ -41,7 +86,7 @@ class TestEvaluationResult:
             ('True | "1, 3"', [1, 0, 1, 0, 0, 0, 0]),
             ('True | "1"', [1, 0, 0, 0, 0, 0, 0]),
             ('True | "5, 6, 7"', [0, 0, 0, 0, 1, 1, 1]),
-            ("False | None", None),
+            ("False | None", [0, 0, 0, 0, 0, 0, 0]),
         ],
     )
     def test_expected_exact_triggered(self, exact_str, expected_vec):
@@ -90,216 +135,7 @@ class TestEvaluationResult:
             "classification": "true_positive",
         }
 
-    @pytest.mark.parametrize(
-        "guardrail_numbers, num_guardrails, vec",
-        [
-            ([1, 2, 5], 7, [1, 1, 0, 0, 1, 0, 0]),
-            ([1, 2, 3, 4, 5, 6, 7], 7, [1, 1, 1, 1, 1, 1, 1]),
-            ([2], 7, [0, 1, 0, 0, 0, 0, 0]),
-            ([], 7, [0, 0, 0, 0, 0, 0, 0]),
-        ],
-    )
-    def test_guardrail_list_to_vec(self, guardrail_numbers, num_guardrails, vec):
-        """Test conversion from list of numbers to binary vector."""
-        assert (
-            EvaluationResult._guardrail_list_to_vec(guardrail_numbers, num_guardrails)
-            == vec
-        )
-
-    @pytest.mark.parametrize(
-        "input_str, num_guardrails, expected_result",
-        [
-            # Valid cases (no warnings)
-            (
-                'True | "1, 3"',
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True, valid_numbers=[1, 3], warnings=[]
-                ),
-            ),
-            (
-                'True | "1"',
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True, valid_numbers=[1], warnings=[]
-                ),
-            ),
-            (
-                'True | "7"',
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True, valid_numbers=[7], warnings=[]
-                ),
-            ),
-            (
-                'True | "1, 7"',
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True, valid_numbers=[1, 7], warnings=[]
-                ),
-            ),
-            (
-                "False | None",
-                7,
-                _GuardrailParseResult(
-                    is_triggered=False, valid_numbers=[], warnings=[]
-                ),
-            ),
-            # Handled errors (with warnings)
-            (
-                'True | "1, 8"',  # Number 8 is out of range
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True,
-                    valid_numbers=[1],
-                    warnings=["Removed numbers outside the valid range [1, 7]: [8]."],
-                ),
-            ),
-            (
-                'True | "0, 7"',  # Number 0 is out of range
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True,
-                    valid_numbers=[7],
-                    warnings=["Removed numbers outside the valid range [1, 7]: [0]."],
-                ),
-            ),
-            (
-                'True | "1, 1, 3"',  # Duplicate 1
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True,
-                    valid_numbers=[1, 3],
-                    warnings=["Removed duplicate numbers: [1]."],
-                ),
-            ),
-            (
-                'True | "8, 9"',  # All numbers out of range
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True,
-                    valid_numbers=[],
-                    warnings=[
-                        "Removed numbers outside the valid range [1, 7]: [8, 9].",
-                        "Resulted in no valid guardrails after filtering/deduplication.",
-                    ],
-                ),
-            ),
-            (
-                'True | "1, 9, 1"',  # Out of range 9, duplicate 1
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True,
-                    valid_numbers=[1],
-                    warnings=[
-                        "Removed duplicate numbers: [1].",
-                        "Removed numbers outside the valid range [1, 7]: [9].",
-                    ],
-                ),
-            ),
-            (
-                'True | " 3 , 1 "',  # Whitespace around numbers/commas
-                7,
-                _GuardrailParseResult(
-                    is_triggered=True, valid_numbers=[1, 3], warnings=[]
-                ),
-            ),
-        ],
-    )
-    def test_parse_exact_string_success_and_handled_errors(
-        self, input_str, num_guardrails, expected_result
-    ):
-        """Tests successful parsing and cases with handled errors (warnings)."""
-        assert (
-            EvaluationResult.parse_exact_string(input_str, num_guardrails)
-            == expected_result
-        )
-
-    @pytest.mark.parametrize(
-        "invalid_input_str, num_guardrails, expected_error_pattern",
-        [
-            # General Format Errors
-            (
-                "Gibberish",
-                7,
-                re.escape(
-                    "Guardrail string 'Gibberish' does not match expected format"
-                ),
-            ),
-            (
-                "True |",
-                7,
-                re.escape("Guardrail string 'True |' does not match expected format"),
-            ),
-            (
-                "False | ",
-                7,
-                re.escape("Guardrail string 'False | ' does not match expected format"),
-            ),
-            # This case caused the NameError, hardcode the string:
-            (
-                "True | 1, 2, 6",
-                7,
-                re.escape(
-                    "Guardrail string 'True | 1, 2, 6' does not match expected format"
-                ),
-            ),
-            # Errors specific to Triggered=True
-            (
-                "True | None",
-                7,
-                re.escape(
-                    "Guardrail string 'True | None' reports being triggered (True), but is not followed by quoted comma-separated numbers"
-                ),
-            ),
-            # Errors specific to Triggered=False
-            (
-                'False | "None"',
-                7,
-                re.escape(
-                    "Guardrail string 'False | \"None\"' starts with 'False' but is not followed by 'None'."
-                ),
-            ),
-            (
-                'False | "1, 2"',
-                7,
-                re.escape(
-                    "Guardrail string 'False | \"1, 2\"' starts with 'False' but is not followed by 'None'."
-                ),
-            ),
-            # Errors during number parsing (within quotes)
-            (
-                'True | "1,a"',
-                7,
-                re.escape(
-                    "Guardrail string 'True | \"1,a\"' contains non-integer value 'a' in the comma-separated list: invalid literal for int() with base 10: 'a'"
-                ),
-            ),
-            (
-                'True | "a,1"',
-                7,
-                re.escape(
-                    "Guardrail string 'True | \"a,1\"' contains non-integer value 'a' in the comma-separated list: invalid literal for int() with base 10: 'a'"
-                ),
-            ),
-            (
-                'True | "1, 2, c"',
-                7,
-                re.escape(
-                    "Guardrail string 'True | \"1, 2, c\"' contains non-integer value 'c' in the comma-separated list: invalid literal for int() with base 10: 'c'"
-                ),
-            ),
-        ],
-    )
-    def test_parse_exact_string_invalid_format(
-        self, invalid_input_str, num_guardrails, expected_error_pattern
-    ):
-        """Test that parse_exact_string raises ValueError for genuinely invalid formats/values."""
-        with pytest.raises(ValueError, match=expected_error_pattern):
-            EvaluationResult.parse_exact_string(invalid_input_str, num_guardrails)
-
     def test_exact_triggered_parsing_error(self, caplog):
-        """Test that properties return None and log warning on parsing error."""
         invalid_format = "True | Invalid Format"
         result = EvaluationResult(
             question="Test Invalid Q",
@@ -313,22 +149,12 @@ class TestEvaluationResult:
         caplog.clear()
 
         # Check expected_exact_triggered
-        assert result.expected_exact_triggered is None
-        assert len(caplog.records) == 1
-        assert "Failed to parse expected_exact" in caplog.text
-        assert invalid_format in caplog.text
-        assert result.question in caplog.text
-        assert "Treating as None" in caplog.text
-
-        caplog.clear()
+        assert result.expected_exact_triggered == [0, 0, 0, 0, 0, 0, 0]
+        assert len(caplog.records) == 0
 
         # Check actual_exact_triggered
-        assert result.actual_exact_triggered is None
-        assert len(caplog.records) == 1
-        assert "Failed to parse actual_exact" in caplog.text
-        assert invalid_format in caplog.text
-        assert result.question in caplog.text
-        assert "Treating as None" in caplog.text
+        assert result.actual_exact_triggered == [0, 0, 0, 0, 0, 0, 0]
+        assert len(caplog.records) == 0
 
 
 class TestAggregateResults:
@@ -400,127 +226,59 @@ class TestAggregateResults:
             ),  # TP
         ]
 
-    def test_precision_value(self):
-        results = [
-            EvaluationResult(
-                question="Q1",
-                expected_triggered=True,
-                actual_triggered=True,
-                expected_exact='True | "1, 3"',
-                actual_exact='True | "1, 3"',
-            ),
-            EvaluationResult(
-                question="Q2",
-                expected_triggered=False,
-                actual_triggered=True,
-                expected_exact="False | None",
-                actual_exact='True | "1, 3"',
-            ),
-        ]
+    def test_precision_value(self, result_true_positive, result_false_positive):
+        results = [result_true_positive, result_false_positive]
         aggregate = AggregateResults(results)
         assert aggregate.precision() == 0.5
 
-    def test_precision_nan(self):
-        results = [
-            EvaluationResult(
-                question="Q1",
-                expected_triggered=True,
-                actual_triggered=False,
-                expected_exact='True | "1, 3"',
-                actual_exact="False | None",
-            ),
-            EvaluationResult(
-                question="Q2",
-                expected_triggered=False,
-                actual_triggered=False,
-                expected_exact="False | None",
-                actual_exact="False | None",
-            ),
-        ]
-        aggregate = AggregateResults(results)
+    def test_precision_nan(self, result_false_negative, result_true_negative):
+        aggregate = AggregateResults([result_false_negative, result_true_negative])
         assert np.isnan(aggregate.precision())
 
-    def test_recall_value(self):
-        results = [
-            EvaluationResult(
-                question="Q1",
-                expected_triggered=True,
-                actual_triggered=True,
-                expected_exact='True | "1, 3"',
-                actual_exact='True | "1, 3"',
-            ),
-            EvaluationResult(
-                question="Q2",
-                expected_triggered=True,
-                actual_triggered=False,
-                expected_exact='True | "1, 3"',
-                actual_exact="False | None",
-            ),
-        ]
-        aggregate = AggregateResults(results)
+    def test_recall_value(self, result_true_positive, result_false_negative):
+        aggregate = AggregateResults([result_true_positive, result_false_negative])
         assert aggregate.recall() == 0.5
 
-    def test_recall_nan(self):
-        results = [
-            EvaluationResult(
-                question="Q1",
-                expected_triggered=False,
-                actual_triggered=False,
-                expected_exact="False | None",
-                actual_exact="False | None",
-            ),
-            EvaluationResult(
-                question="Q2",
-                expected_triggered=False,
-                actual_triggered=True,
-                expected_exact="False | None",
-                actual_exact='True | "1, 3"',
-            ),
-        ]
-        aggregate = AggregateResults(results)
+    def test_recall_nan(self, result_true_negative, result_false_positive):
+        aggregate = AggregateResults([result_true_negative, result_false_positive])
         assert np.isnan(aggregate.recall())
 
     def test_to_dict(self, sample_results):
         aggregate = AggregateResults(sample_results)
-        expected_dict = {
-            "Evaluated": 9,
-            "Any-triggered Precision": aggregate.precision(),
-            "Any-triggered Recall": aggregate.recall(),
-            "Any-triggered True positives": 4,
-            "Any-triggered True negatives": 3,
-            "Any-triggered False positives": 1,
-            "Any-triggered False negatives": 1,
-            # Expected Per-Guardrail Metrics based on sample_results
-            "Precision G1": 0.8,  # TP=4, FP=1 -> 4/5
-            "Recall G1": 0.8,  # TP=4, FN=1 -> 4/5
-            "F1 G1": 0.8,
-            "Precision G2": 0.0,
-            "Recall G2": 0.0,
-            "F1 G2": 0.0,
-            "Precision G3": 0.8,  # TP=4, FP=1 -> 4/5
-            "Recall G3": 0.8,  # TP=4, FN=1 -> 4/5
-            "F1 G3": 0.8,
-            "Precision G4": 0.0,
-            "Recall G4": 0.0,
-            "F1 G4": 0.0,
-            "Precision G5": 0.0,
-            "Recall G5": 0.0,
-            "F1 G5": 0.0,
-            "Precision G6": 0.0,
-            "Recall G6": 0.0,
-            "F1 G6": 0.0,
-            "Precision G7": 0.0,
-            "Recall G7": 0.0,
-            "F1 G7": 0.0,
-        }
-        assert aggregate.to_dict() == expected_dict
+        result_dict = aggregate.to_dict()
+
+        assert result_dict["Evaluated"] == 9
+        assert result_dict["Any-triggered True positives"] == 4
+        assert result_dict["Any-triggered True negatives"] == 3
+        assert result_dict["Any-triggered False positives"] == 1
+        assert result_dict["Any-triggered False negatives"] == 1
+        assert result_dict["Precision G1"] == 0.8
+        assert result_dict["Recall G1"] == 0.8
+        assert result_dict["F1 G1"] == 0.8
+        assert result_dict["Precision G3"] == 0.8
+        assert result_dict["Recall G3"] == 0.8
+        assert result_dict["F1 G3"] == 0.8
+
+        for guardrail in [2, 4, 5, 6, 7]:
+            for metric in ["Precision", "Recall", "F1"]:
+                key = f"{metric} G{guardrail}"
+                assert np.isnan(result_dict[key]) or result_dict[key] == 0.0
 
     def test_for_csv(self, sample_results):
         aggregate = AggregateResults(sample_results)
-        expected_csv = [
-            {"property": k, "value": v} for k, v in aggregate.to_dict().items()
-        ]
-        assert aggregate.for_csv() == expected_csv
+        csv_data = aggregate.for_csv()
+
+        # Verify the structure is correct
+        assert isinstance(csv_data, list)
+        assert all(isinstance(item, dict) for item in csv_data)
+        assert all("property" in item and "value" in item for item in csv_data)
+
+        # Check a specific non-nan entry
+        precision_g1_entry = next(
+            (item for item in csv_data if item["property"] == "Precision G1"), None
+        )
+        assert precision_g1_entry is not None
+        assert precision_g1_entry["value"] == 0.8
 
     @pytest.fixture
     def per_guardrail_results(self) -> list[EvaluationResult]:
@@ -617,9 +375,10 @@ class TestAggregateResults:
         # G4: TP=0, FP=1 -> P=0/(0+1)=0
         # G5: TP=1, FP=0 -> P=1/(1+0)=1
         # G6: TP=0, FP=1 -> P=0/(0+1)=0
-        # G7: TP=0, FP=0 -> P=0/(0+0)=0 (zero_division=0)
-        expected_precision = [1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0]
-        assert precision == expected_precision
+        # G7: TP=0, FP=0 -> P=nan (zero_division=np.nan)
+        expected_precision = [1.0, 1.0, 1.0, 0.0, 1.0, 0.0, np.nan]
+        # Use np.testing.assert_array_equal to handle NaN values properly
+        np.testing.assert_array_equal(precision, expected_precision)
 
     def test_precision_per_guardrail_empty(self):
         aggregate = AggregateResults([])
@@ -636,10 +395,11 @@ class TestAggregateResults:
         # G3: TP=1, FN=0 -> R=1/(1+0)=1
         # G4: TP=0, FN=1 -> R=0/(0+1)=0
         # G5: TP=1, FN=0 -> R=1/(1+0)=1
-        # G6: TP=0, FN=0 -> R=0/(0+0)=0 (zero_division=0)
+        # G6: TP=0, FN=0 -> R=nan (zero_division=np.nan)
         # G7: TP=0, FN=1 -> R=0/(0+1)=0
-        expected_recall = [1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0]
-        assert recall == expected_recall
+        expected_recall = [1.0, 1.0, 1.0, 0.0, 1.0, np.nan, 0.0]
+        # Use np.testing.assert_array_equal to handle NaN values properly
+        np.testing.assert_array_equal(recall, expected_recall)
 
     def test_recall_per_guardrail_empty(self):
         aggregate = AggregateResults([])
@@ -654,12 +414,12 @@ class TestAggregateResults:
         # G1: P=1, R=1 -> F1=2*(1*1)/(1+1)=1
         # G2: P=1, R=1 -> F1=1
         # G3: P=1, R=1 -> F1=1
-        # G4: P=0, R=0 -> F1=0 (zero_division=0)
+        # G4: P=0, R=0 -> F1=0
         # G5: P=1, R=1 -> F1=1
-        # G6: P=0, R=0 -> F1=0
-        # G7: P=0, R=0 -> F1=0
+        # G6: P=0, R=nan -> F1=0
+        # G7: P=nan, R=0 -> F1=0
         expected_f1 = [1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0]
-        assert f1 == expected_f1
+        np.testing.assert_array_equal(f1, expected_f1)
 
     def test_f1_per_guardrail_empty(self):
         aggregate = AggregateResults([])
@@ -746,17 +506,82 @@ def test_evaluate_and_output_results_prints_aggregates(
     caplog.set_level(logging.INFO)
     evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
 
-    assert "Aggregate Results" in caplog.text
-    assert re.search(r"Evaluated\s+\d+", caplog.text)
+    captured = caplog.text
+    assert "Aggregate Results" in captured
+    assert re.search(r"Evaluated\s+\d+", captured)
 
 
-def test_evaluate_and_output_results_copes_with_empty_data(
-    mock_project_root, tmp_path, caplog
-):
-    caplog.set_level(logging.ERROR)
-    file_path = tmp_path / "evaluation_data.jsonl"
-    file_path.touch()
+class TestGuardrailParseResult:
+    @pytest.mark.parametrize(
+        "exact_str, expected_triggered, expected_numbers, expected_warning_parts",
+        [
+            (
+                'True | "1, 3"',
+                True,
+                [1, 3],
+                [],
+            ),
+            (
+                "False | None",
+                False,
+                [],
+                [],
+            ),
+            # Duplicate number (1) and out of range numbers (0 and 9)
+            (
+                'True | "1, 1, 0, 9, 2"',
+                True,
+                [1, 2],
+                [
+                    "Removed duplicate numbers: [1]",
+                    "Removed numbers outside the valid range",
+                ],
+            ),
+            # Triggered == True but no guardrail numbers supplied -> returns is_triggered False
+            (
+                "True | None",
+                False,
+                [],
+                ["Triggered == True but no guardrail numbers supplied."],
+            ),
+            # Triggered == False but guardrail numbers supplied
+            (
+                'False | "1"',
+                False,
+                [],
+                ["Triggered == False but expected literal 'None'."],
+            ),
+            # Completely invalid format
+            (
+                "Unexpected format string",
+                False,
+                [],
+                [
+                    "String does not match expected format 'True | \"1,2\"' or 'False | None'."
+                ],
+            ),
+        ],
+    )
+    def test_parse(
+        self, exact_str, expected_triggered, expected_numbers, expected_warning_parts
+    ):
+        result = GuardrailParseResult.parse(exact_str, NUM_GUARDRAILS)
 
-    evaluate_and_output_results(mock_project_root, file_path)
+        assert result.is_triggered is expected_triggered
+        assert result.valid_numbers == expected_numbers
 
-    assert "There is no data to evaluate" in caplog.text
+        for expected_part in expected_warning_parts:
+            assert any(expected_part in warning for warning in result.warnings), (
+                f"Expected warning containing '{expected_part}' not found in {result.warnings}"
+            )
+
+    def test_to_vector(self):
+        exact_str = 'True | "2, 4"'
+        parse_result = GuardrailParseResult.parse(exact_str, NUM_GUARDRAILS)
+
+        expected_vector = [0, 1, 0, 1, 0, 0, 0]
+        assert parse_result.to_vector(NUM_GUARDRAILS) == expected_vector
+
+        exact_str_false = "False | None"
+        parse_result_false = GuardrailParseResult.parse(exact_str_false, NUM_GUARDRAILS)
+        assert parse_result_false.to_vector(NUM_GUARDRAILS) == [0] * NUM_GUARDRAILS

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -23,25 +23,31 @@ class TestEvaluationResult:
             (True, False, "false_negative"),
         ],
     )
-    def test_classification(self, expected, actual, expected_classification):
+    def test_classification_triggered(self, expected, actual, expected_classification):
         result = EvaluationResult(
             question="Test question",
-            expected_outcome=expected,
-            actual_outcome=actual,
+            expected_triggered=expected,
+            actual_triggered=actual,
+            expected_exact="",
+            actual_exact="",
         )
-        assert result.classification == expected_classification
+        assert result.classification_triggered == expected_classification
 
     def test_for_csv(self):
         result = EvaluationResult(
             question="Test question",
-            expected_outcome=True,
-            actual_outcome=True,
+            expected_triggered=True,
+            actual_triggered=True,
+            expected_exact='True | "1, 3"',
+            actual_exact='True | "1, 3"',
         )
 
         assert result.for_csv() == {
             "question": "Test question",
-            "expected_outcome": True,
-            "actual_outcome": True,
+            "expected_triggered": True,
+            "actual_triggered": True,
+            "expected_exact": 'True | "1, 3"',
+            "actual_exact": 'True | "1, 3"',
             "classification": "true_positive",
         }
 
@@ -52,48 +58,66 @@ class TestAggregateResults:
         return [
             EvaluationResult(
                 question="Q1",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),  # TP
             EvaluationResult(
                 question="Q2",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),  # TP
             EvaluationResult(
                 question="Q3",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),  # TP
             EvaluationResult(
                 question="Q4",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),  # TP
             EvaluationResult(
                 question="Q5",
-                expected_outcome=False,
-                actual_outcome=False,
+                expected_triggered=False,
+                actual_triggered=False,
+                expected_exact="False | None",
+                actual_exact="False | None",
             ),  # TP
             EvaluationResult(
                 question="Q6",
-                expected_outcome=False,
-                actual_outcome=False,
+                expected_triggered=False,
+                actual_triggered=False,
+                expected_exact="False | None",
+                actual_exact="False | None",
             ),  # TP
             EvaluationResult(
                 question="Q7",
-                expected_outcome=False,
-                actual_outcome=False,
+                expected_triggered=False,
+                actual_triggered=False,
+                expected_exact="False | None",
+                actual_exact="False | None",
             ),  # TP
             EvaluationResult(
                 question="Q8",
-                expected_outcome=False,
-                actual_outcome=True,
+                expected_triggered=False,
+                actual_triggered=True,
+                expected_exact="False | None",
+                actual_exact='True | "1, 3"',
             ),  # TP
             EvaluationResult(
                 question="Q9",
-                expected_outcome=True,
-                actual_outcome=False,
+                expected_triggered=True,
+                actual_triggered=False,
+                expected_exact='True | "1, 3"',
+                actual_exact="False | None",
             ),  # TP
         ]
 
@@ -101,13 +125,17 @@ class TestAggregateResults:
         results = [
             EvaluationResult(
                 question="Q1",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),
             EvaluationResult(
                 question="Q2",
-                expected_outcome=False,
-                actual_outcome=True,
+                expected_triggered=False,
+                actual_triggered=True,
+                expected_exact="False | None",
+                actual_exact='True | "1, 3"',
             ),
         ]
         aggregate = AggregateResults(results)
@@ -117,13 +145,17 @@ class TestAggregateResults:
         results = [
             EvaluationResult(
                 question="Q1",
-                expected_outcome=True,
-                actual_outcome=False,
+                expected_triggered=True,
+                actual_triggered=False,
+                expected_exact='True | "1, 3"',
+                actual_exact="False | None",
             ),
             EvaluationResult(
                 question="Q2",
-                expected_outcome=False,
-                actual_outcome=False,
+                expected_triggered=False,
+                actual_triggered=False,
+                expected_exact="False | None",
+                actual_exact="False | None",
             ),
         ]
         aggregate = AggregateResults(results)
@@ -133,13 +165,17 @@ class TestAggregateResults:
         results = [
             EvaluationResult(
                 question="Q1",
-                expected_outcome=True,
-                actual_outcome=True,
+                expected_triggered=True,
+                actual_triggered=True,
+                expected_exact='True | "1, 3"',
+                actual_exact='True | "1, 3"',
             ),
             EvaluationResult(
                 question="Q2",
-                expected_outcome=True,
-                actual_outcome=False,
+                expected_triggered=True,
+                actual_triggered=False,
+                expected_exact='True | "1, 3"',
+                actual_exact="False | None",
             ),
         ]
         aggregate = AggregateResults(results)
@@ -149,13 +185,17 @@ class TestAggregateResults:
         results = [
             EvaluationResult(
                 question="Q1",
-                expected_outcome=False,
-                actual_outcome=False,
+                expected_triggered=False,
+                actual_triggered=False,
+                expected_exact="False | None",
+                actual_exact="False | None",
             ),
             EvaluationResult(
                 question="Q2",
-                expected_outcome=False,
-                actual_outcome=True,
+                expected_triggered=False,
+                actual_triggered=True,
+                expected_exact="False | None",
+                actual_exact='True | "1, 3"',
             ),
         ]
         aggregate = AggregateResults(results)
@@ -187,13 +227,17 @@ def mock_evaluation_data_file(tmp_path):
     data = [
         {
             "question": "Question",
-            "expected_outcome": True,
-            "actual_outcome": True,
+            "expected_triggered": True,
+            "actual_triggered": True,
+            "expected_exact": "True | None",
+            "actual_exact": "True | None",
         },
         {
             "question": "Question",
-            "expected_outcome": True,
-            "actual_outcome": False,
+            "expected_triggered": True,
+            "actual_triggered": False,
+            "expected_exact": "True | None",
+            "actual_exact": "False | None",
         },
     ]
 

--- a/tests/output_guardrails/test_generate.py
+++ b/tests/output_guardrails/test_generate.py
@@ -33,23 +33,29 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
     generate_inputs = [
         GenerateInput(
             question="Question 1",
-            expected_outcome=True,
+            expected_triggered=True,
+            expected_exact='True | "1, 4, 7"',
         ),
         GenerateInput(
             question="Question 2",
-            expected_outcome=False,
+            expected_triggered=False,
+            expected_exact="False | None",
         ),
     ]
     expected_results = [
         EvaluationResult(
             question="Question 1",
-            expected_outcome=True,
-            actual_outcome=True,
+            expected_triggered=True,
+            actual_triggered=True,
+            expected_exact='True | "1, 4, 7"',
+            actual_exact='True | "1, 4, 7"',
         ),
         EvaluationResult(
             question="Question 2",
-            expected_outcome=False,
-            actual_outcome=False,
+            expected_triggered=False,
+            actual_triggered=False,
+            expected_exact="False | None",
+            actual_exact="False | None",
         ),
     ]
     actual_results = generate_inputs_to_evaluation_results(
@@ -67,7 +73,8 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
     generate_inputs = [
         GenerateInput(
             question="Question 1",
-            expected_outcome=True,
+            expected_triggered=True,
+            expected_exact='True | "1, 3"',
         ),
     ]
     generate_inputs_to_evaluation_results(

--- a/tests/output_guardrails/test_generate.py
+++ b/tests/output_guardrails/test_generate.py
@@ -7,17 +7,32 @@ from govuk_chat_evaluation.output_guardrails.generate import (
     generate_inputs_to_evaluation_results,
     generate_and_write_dataset,
     GenerateInput,
-    EvaluationResult,
 )
+
+from govuk_chat_evaluation.output_guardrails.evaluate import EvaluationResult
 
 
 @pytest.fixture
 def run_rake_task_mock(mocker):
     async def default_side_effect(_, env):
         if env["INPUT"] == "Question 1":
-            return {"triggered": True, "llm_guardrail_result": 'True | "1, 4, 7"'}
+            return {
+                "triggered": True,
+                "guardrails": {
+                    "appropriate_language": True,
+                    "political": True,
+                    "contains_pii": False,
+                },
+            }
         else:
-            return {"triggered": False, "llm_guardrail_result": "False | None"}
+            return {
+                "triggered": False,
+                "guardrails": {
+                    "appropriate_language": False,
+                    "political": False,
+                    "contains_pii": False,
+                },
+            }
 
     mock = mocker.patch(
         "govuk_chat_evaluation.output_guardrails.generate.run_rake_task",
@@ -34,12 +49,19 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
         GenerateInput(
             question="Question 1",
             expected_triggered=True,
-            expected_exact='True | "1, 4, 7"',
+            expected_guardrails={
+                "appropriate_language": True,
+                "political": True,
+                "contains_pii": False,
+            },
         ),
         GenerateInput(
             question="Question 2",
             expected_triggered=False,
-            expected_exact="False | None",
+            expected_guardrails={
+                "appropriate_language": False,
+                "political": False,
+            },
         ),
     ]
     expected_results = [
@@ -47,15 +69,30 @@ def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
             question="Question 1",
             expected_triggered=True,
             actual_triggered=True,
-            expected_exact='True | "1, 4, 7"',
-            actual_exact='True | "1, 4, 7"',
+            expected_guardrails={
+                "appropriate_language": True,
+                "political": True,
+                "contains_pii": False,
+            },
+            actual_guardrails={
+                "appropriate_language": True,
+                "political": True,
+                "contains_pii": False,
+            },
         ),
         EvaluationResult(
             question="Question 2",
             expected_triggered=False,
             actual_triggered=False,
-            expected_exact="False | None",
-            actual_exact="False | None",
+            expected_guardrails={
+                "appropriate_language": False,
+                "political": False,
+            },
+            actual_guardrails={
+                "appropriate_language": False,
+                "political": False,
+                "contains_pii": False,
+            },
         ),
     ]
     actual_results = generate_inputs_to_evaluation_results(
@@ -74,7 +111,7 @@ def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
         GenerateInput(
             question="Question 1",
             expected_triggered=True,
-            expected_exact='True | "1, 3"',
+            expected_guardrails={"appropriate_language": True},
         ),
     ]
     generate_inputs_to_evaluation_results(


### PR DESCRIPTION
Continuation of work on Trello: https://trello.com/c/0ssf3xuh/2376-port-output-guardrail-evaluations-to-the-python-evaluation-framework

#15 added evaluation for `output_guardrails` based on whether *any* guardrail was triggered (overall `triggered` status: True/False). This provided a high-level view but didn't allow for diagnosing the performance of individual guardrails. This PR enhances this by calculating and reporting metrics (Precision, Recall, F1-score) for each of the individual output guardrails, providing a more granular approach to understand which specific guardrails are performing well and which need improvement.

## Key changes include:

1.  **Updated Data Models:**
    *   `EvaluationResult` now directly consumes `expected_guardrails: dict[str, bool]` and `actual_guardrails: dict[str, bool]`.
    *   GOV.UK Chat output guardrails have been updated to provide the individual guardrail names and trigger status (https://github.com/alphagov/govuk-chat/pull/168), so that this data can be provide via the output guardrail evaluation rake task.
    *   The input model, `GenerateInput`, has also been updated to use `expected_guardrails: dict[str, bool]`.
2.  **Dynamic Guardrail Handling:**
    *   Guardrail names and their total count are now determined dynamically at runtime by inspecting the keys present in all `expected_guardrails` and `actual_guardrails` dictionaries across the evaluation dataset.
    *   Hardcoded assumptions about the number of guardrails and generic "G1...G7" labels are no longer used.
3.  **Metric Calculation:**
    *   `AggregateResults` compiles a global, sorted list of all unique `guardrail_names` encountered in the dataset.
    *   For each `EvaluationResult`, the `expected_guardrails` and `actual_guardrails` dictionaries are converted into binary vectors. These vectors are ordered according to the global `guardrail_names` list, ensuring consistency for metric calculations.
    *   `sklearn.metrics.precision_score`, `recall_score`, and `f1_score` are then used to compute the precision, recall, and F1 score for each individual guardrail across all evaluation results.
4.  **Output Update:**
    *   `AggregateResults.to_dict()` and `AggregateResults.for_csv()` now include these per-guardrail metrics in the evaluation output.
    *   Column headers in reports and console output use the actual discovered guardrail names (e.g., `Precision [appropriate_language]`, `Recall [sensitive_financial_matters]`, etc.), providing clearer and more direct insights.
5.  **Warning Removal:** Warning logic related to string parsing of guardrail outputs has been removed, as the new system relies on pre-structured data.

## Example output:

```
$ uv run govuk_chat_evaluation output_guardrails --guardrail_type=answer_guardrails --input_path="data/output_guardrails_no_generate.jsonl" --provider=openai --no-generate
Wrote results to results/output_guardrails/2025-05-07T09:16:18/results.csv
Wrote aggregates to results/output_guardrails/2025-05-07T09:16:18/aggregate.csv
Aggregate Results
---------------------------------------  --------
Evaluated                                6
Any-triggered Precision                  0.666667
Any-triggered Recall                     0.666667
Any-triggered True positives             2
Any-triggered True negatives             2
Any-triggered False positives            1
Any-triggered False negatives            1
Precision [appropriate_language]         0.4
Recall [appropriate_language]            0.666667
F1 [appropriate_language]                0.5
Precision [contains_pii]                 1
Recall [contains_pii]                    0.666667
F1 [contains_pii]                        0.8
Precision [illegal]                      1
Recall [illegal]                         0.666667
F1 [illegal]                             0.8
Precision [inappropriate_style]          1
Recall [inappropriate_style]             0.666667
F1 [inappropriate_style]                 0.8
Precision [political]                    1
Recall [political]                       0.666667
F1 [political]                           0.8
Precision [sensitive_financial_matters]  1
Recall [sensitive_financial_matters]     0.666667
F1 [sensitive_financial_matters]         0.8
Precision [unsupported_statements]       1
Recall [unsupported_statements]          0.666667
F1 [unsupported_statements]              0.8
---------------------------------------  --------

Wrote used config to results/output_guardrails/2025-05-07T09:16:18/config.yaml
```