### PR TITLE
Add evaluation for question routing

### DIFF
--- a/config/defaults/question_router.yaml
+++ b/config/defaults/question_router.yaml
@@ -1,0 +1,4 @@
+what: Evaluating question router
+generate: true
+provider: claude
+input_path: data/question_router.jsonl

--- a/govuk_chat_evaluation/cli.py
+++ b/govuk_chat_evaluation/cli.py
@@ -2,6 +2,7 @@ import click
 
 from . import jailbreak_guardrails
 from . import output_guardrails
+from . import question_router
 
 
 @click.group()
@@ -11,3 +12,4 @@ def main():
 
 main.add_command(jailbreak_guardrails.main)
 main.add_command(output_guardrails.main)
+main.add_command(question_router.main)

--- a/govuk_chat_evaluation/question_router/__init__.py
+++ b/govuk_chat_evaluation/question_router/__init__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+__all__ = ["main"]

--- a/govuk_chat_evaluation/question_router/cli.py
+++ b/govuk_chat_evaluation/question_router/cli.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Self, cast
+
+import click
+from pydantic import model_validator
+
+from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
+from ..file_system import create_output_directory, write_config_file_for_reuse
+from .evaluate import evaluate_and_output_results
+from .generate import generate_and_write_dataset
+
+
+class Config(BaseConfig):
+    what: BaseConfig.GenericFields.what
+    generate: BaseConfig.GenericFields.generate
+    provider: BaseConfig.GenericFields.provider_openai_or_claude
+    input_path: BaseConfig.GenericFields.input_path
+
+    @model_validator(mode="after")
+    def run_validatons(self) -> Self:
+        return self._validate_fields_required_for_generate("provider")
+
+
+@click.command(name="question_router")
+@click.argument(
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default="config/defaults/question_router.yaml",
+)
+@apply_click_options_to_command(Config)
+def main(**cli_args):
+    """Run question router evaluation"""
+    start_time = datetime.now()
+
+    config: Config = config_from_cli_args(
+        config_path=cli_args["config_path"],
+        config_cls=Config,
+        cli_args=cli_args,
+    )
+
+    output_dir = create_output_directory("question_router", start_time)
+
+    if config.generate:
+        evaluate_path = generate_and_write_dataset(
+            config.input_path, cast(str, config.provider), output_dir
+        )
+    else:
+        evaluate_path = config.input_path
+
+    evaluate_and_output_results(output_dir, evaluate_path)
+
+    write_config_file_for_reuse(output_dir, config)

--- a/govuk_chat_evaluation/question_router/evaluate.py
+++ b/govuk_chat_evaluation/question_router/evaluate.py
@@ -1,0 +1,182 @@
+from functools import cached_property
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    f1_score,
+    fbeta_score,
+    confusion_matrix,
+)
+from tabulate import tabulate
+import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
+
+from ..file_system import jsonl_to_models, write_csv_results
+
+
+class EvaluationResult(BaseModel):
+    question: str
+    expected_outcome: str
+    actual_outcome: str
+    confidence_score: float
+
+    def for_csv(self) -> dict[str, Any]:
+        return {**self.model_dump()}
+
+
+class AggregateResults:
+    def __init__(self, evaluation_results: list[EvaluationResult]):
+        self.evaluation_results = evaluation_results
+
+    @cached_property
+    def classification_labels(self) -> list[str]:
+        return sorted(
+            list(set(item for lst in self._expected_actual_lists for item in lst))
+        )
+
+    @cached_property
+    def _expected_actual_lists(self) -> tuple[list[str], list[str]]:
+        pairs_list = [
+            (eval.expected_outcome, eval.actual_outcome)
+            for eval in self.evaluation_results
+        ]
+
+        expected, actual = zip(*pairs_list)
+        return list(expected), list(actual)
+
+    def accuracy(self) -> float:
+        return accuracy_score(
+            *self._expected_actual_lists,  # type: ignore
+        )
+
+    def precision(self) -> float:
+        return precision_score(
+            *self._expected_actual_lists,
+            average="weighted",
+            zero_division=np.nan,  # type: ignore
+        )
+
+    def recall(self) -> float:
+        return recall_score(
+            *self._expected_actual_lists,
+            average="weighted",
+            zero_division=np.nan,  # type: ignore
+        )
+
+    def f1_score(self) -> float:
+        return f1_score(
+            *self._expected_actual_lists,
+            average="weighted",
+            zero_division=np.nan,  # type: ignore
+        )
+
+    def f2_score(self) -> float:
+        return fbeta_score(
+            *self._expected_actual_lists,
+            beta=2,
+            average="weighted",
+            zero_division=np.nan,  # type: ignore
+        )
+
+    def confusion_matrix_data(self) -> list[list[int]]:
+        return confusion_matrix(
+            *self._expected_actual_lists,
+            labels=sorted(list(set(self.classification_labels))),  # type: ignore
+        )
+
+    def miscategorised_cases(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "question": result.question,
+                "predicted_classification": result.expected_outcome,
+                "actual_classification": result.actual_outcome,
+                "confidence_score": result.confidence_score,
+            }
+            for result in self.evaluation_results
+            if result.expected_outcome != result.actual_outcome
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "Evaluated": len(self.evaluation_results),
+            "Accuracy": self.accuracy(),
+            "Precision": self.precision(),
+            "Recall": self.recall(),
+            "F1 Score": self.f1_score(),
+            "F2 Score": self.f2_score(),
+            "Miscategorised Cases": len(self.miscategorised_cases()),
+        }
+
+    def for_csv(self) -> list[dict[str, Any]]:
+        return [{"property": k, "value": v} for k, v in self.to_dict().items()]
+
+
+def generate_and_output_confusion_matrix(
+    output_dir: Path,
+    confusion_matrix_data: list[list[int]],
+    confusion_matrix_labels: list[str],
+):
+    """Takes confusion matrix data (a 2D list) calculated by sklearn
+    and a list of labels (strings representing the question routing labels)
+    and outputs an confusion matrix PNG image to the output directory"""
+    fig, ax = plt.subplots(figsize=(6, 6))
+    sns.heatmap(
+        confusion_matrix_data,  # type: ignore
+        annot=True,
+        fmt="d",
+        cmap="Blues",
+        xticklabels=confusion_matrix_labels,
+        yticklabels=confusion_matrix_labels,
+        ax=ax,
+        annot_kws={"size": 8},
+        cbar=False,
+    )
+    plt.title("Confusion Matrix", fontsize=8)
+    plt.xlabel("Predicted", fontsize=8)
+    plt.ylabel("True", fontsize=8)
+    ax.xaxis.set_ticklabels(
+        ax.xaxis.get_ticklabels(), rotation=45, ha="right", fontsize=6
+    )
+    ax.yaxis.set_ticklabels(ax.yaxis.get_ticklabels(), rotation=0, fontsize=6)
+    plt.tight_layout()
+    plt.savefig(output_dir / "confusion_matrix.png")
+
+
+def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
+    """Evaluate the data in the evaluation data file and write result files
+    to the output paths, with aggregates written to STDOUT"""
+
+    print("\nEvaluation complete")
+    models = jsonl_to_models(evaluation_data_path, EvaluationResult)
+    write_csv_results(output_dir, [model.for_csv() for model in models])
+
+    aggregate_results = AggregateResults(models)
+
+    write_csv_results(
+        output_dir,
+        aggregate_results.for_csv(),
+        filename="aggregate.csv",
+        data_label="aggregates",
+    )
+
+    generate_and_output_confusion_matrix(
+        output_dir,
+        aggregate_results.confusion_matrix_data(),
+        aggregate_results.classification_labels,
+    )
+
+    write_csv_results(
+        output_dir,
+        aggregate_results.miscategorised_cases(),
+        filename="miscategorised_cases.csv",
+        data_label="miscategorised_cases",
+    )
+
+    table = [[k, v] for k, v in aggregate_results.to_dict().items()]
+    print("\nAggregate Results")
+    print(tabulate(table) + "\n")

--- a/govuk_chat_evaluation/question_router/generate.py
+++ b/govuk_chat_evaluation/question_router/generate.py
@@ -1,0 +1,44 @@
+import asyncio
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from .evaluate import EvaluationResult
+from ..dataset_generation import generate_dataset, run_rake_task
+from ..file_system import jsonl_to_models, write_generated_to_output
+
+
+class GenerateInput(BaseModel):
+    question: str
+    expected_outcome: str
+
+
+def generate_and_write_dataset(input_path: Path, provider: str, output_dir: Path):
+    models = jsonl_to_models(Path(input_path), GenerateInput)
+    generated = generate_inputs_to_evaluation_results(provider, models)
+    return write_generated_to_output(output_dir, generated)
+
+
+def generate_inputs_to_evaluation_results(
+    provider: str, generate_inputs: list[GenerateInput]
+) -> list[EvaluationResult]:
+    """Asynchronously run rake tasks for each GenerateInput instance to
+    generate a result"""
+
+    async def generate_input_to_evaluation_result(input: GenerateInput):
+        env = {"INPUT": input.question}
+        result = await run_rake_task(
+            f"evaluation:generate_question_routing_response[{provider}]",
+            env,
+        )
+
+        return EvaluationResult(
+            question=input.question,
+            expected_outcome=input.expected_outcome,
+            actual_outcome=result["classification"],
+            confidence_score=result["confidence_score"],
+        )
+
+    return asyncio.run(
+        generate_dataset(generate_inputs, generate_input_to_evaluation_result)
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "click>=8.1.8",
+    "matplotlib>=3.10",
     "numpy>=2.2.4",
     "pydantic>=2.10.6",
     "pyyaml>=6.0.2",
     "scikit-learn>=1.6.1",
+    "seaborn>=0.13.2",
     "tabulate>=0.9.0",
     "tqdm>=4.67.1",
 ]

--- a/tests/question_router/conftest.py
+++ b/tests/question_router/conftest.py
@@ -1,0 +1,30 @@
+import json
+
+import pytest
+
+
+@pytest.fixture
+def mock_input_data(mock_project_root):
+    data = [
+        {
+            "question": "Question 1",
+            "expected_outcome": "genuine_rag",
+            "actual_outcome": "genuine_rag",
+            "confidence_score": 0.95,
+        },
+        {
+            "question": "Question 2",
+            "expected_outcome": "greetings",
+            "actual_outcome": "about_mps",
+            "confidence_score": 0.8,
+        },
+    ]
+
+    path = mock_project_root / "input_data.jsonl"
+
+    with open(path, "w") as file:
+        for item in data:
+            json.dump(item, file)
+            file.write("\n")
+
+    return path

--- a/tests/question_router/test_cli.py
+++ b/tests/question_router/test_cli.py
@@ -1,0 +1,127 @@
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from govuk_chat_evaluation.question_router.cli import main, Config
+from govuk_chat_evaluation.question_router.evaluate import EvaluationResult
+
+
+class TestConfig:
+    def test_config_requires_provider_for_generate(self, mock_input_data):
+        with pytest.raises(ValueError, match="provider is required to generate data"):
+            Config(
+                what="Test",
+                generate=True,
+                provider=None,
+                input_path=mock_input_data,
+            )
+
+        Config(
+            what="Test",
+            generate=False,
+            provider=None,
+            input_path=mock_input_data,
+        )
+
+        Config(
+            what="Test",
+            generate=True,
+            provider="openai",
+            input_path=mock_input_data,
+        )
+
+
+@pytest.fixture(autouse=True)
+def mock_config_file(tmp_path, mock_input_data):
+    """Write a config file as an input for testing"""
+    data = {
+        "what": "Testing question router evaluations",
+        "generate": True,
+        "provider": "claude",
+        "input_path": str(mock_input_data),
+    }
+    file_path = tmp_path / "config.yaml"
+    with open(file_path, "w") as file:
+        yaml.dump(data, file)
+
+    yield str(file_path)
+
+
+@pytest.fixture(autouse=True)
+def freeze_time_for_all_tests(freezer):
+    """Automatically freeze time for all tests in this file."""
+    freezer.move_to("2024-11-11 12:34:56")
+
+
+@pytest.fixture
+def mock_data_generation(mocker):
+    return_value = [
+        EvaluationResult(
+            question="Question",
+            expected_outcome="genuine_rag",
+            actual_outcome="genuine_rag",
+            confidence_score=0.95,
+        ),
+        EvaluationResult(
+            question="Question",
+            expected_outcome="greetings",
+            actual_outcome="about_mps",
+            confidence_score=0.8,
+        ),
+    ]
+
+    return mocker.patch(
+        "govuk_chat_evaluation.question_router.generate.generate_inputs_to_evaluation_results",
+        return_value=return_value,
+    )
+
+
+@pytest.fixture
+def mock_output_directory(mock_project_root):
+    return mock_project_root / "results" / "question_router" / "2024-11-11T12:34:56"
+
+
+def test_main_creates_output_files(
+    mock_output_directory, mock_config_file, mock_data_generation
+):
+    runner = CliRunner()
+    result = runner.invoke(main, [mock_config_file])
+
+    config_file = mock_output_directory / "config.yaml"
+    results_file = mock_output_directory / "results.csv"
+    aggregate_file = mock_output_directory / "aggregate.csv"
+    confusion_matrix_file = mock_output_directory / "confusion_matrix.png"
+    miscategorised_cases_file = mock_output_directory / "miscategorised_cases.csv"
+
+    assert result.exit_code == 0, result.output
+    mock_data_generation.assert_called_once()
+    assert mock_output_directory.exists()
+    assert results_file.exists()
+    assert aggregate_file.exists()
+    assert config_file.exists()
+    assert confusion_matrix_file.exists()
+    assert miscategorised_cases_file.exists()
+
+
+def test_main_generates_results(
+    mock_output_directory, mock_config_file, mock_data_generation
+):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, [mock_config_file, "--generate", "--provider", "claude"]
+    )
+
+    generated_file = mock_output_directory / "generated.jsonl"
+
+    assert result.exit_code == 0, result.output
+    mock_data_generation.assert_called_once()
+    assert generated_file.exists()
+
+
+@pytest.mark.usefixtures("mock_output_directory")
+def test_main_doesnt_generate_results(mock_config_file, mock_data_generation):
+    runner = CliRunner()
+    result = runner.invoke(main, [mock_config_file, "--no-generate"])
+
+    assert result.exit_code == 0, result.output
+    mock_data_generation.assert_not_called()

--- a/tests/question_router/test_evaluate.py
+++ b/tests/question_router/test_evaluate.py
@@ -1,0 +1,223 @@
+import csv
+import json
+import re
+
+import pytest
+
+from govuk_chat_evaluation.question_router.evaluate import (
+    AggregateResults,
+    EvaluationResult,
+    evaluate_and_output_results,
+)
+
+
+class TestEvaluationResult:
+    def test_for_csv(self):
+        result = EvaluationResult(
+            question="Test question",
+            expected_outcome="genuine_rag",
+            actual_outcome="greetings",
+            confidence_score=0.9,
+        )
+
+        assert result.for_csv() == {
+            "question": "Test question",
+            "expected_outcome": "genuine_rag",
+            "actual_outcome": "greetings",
+            "confidence_score": 0.9,
+        }
+
+
+class TestAggregateResults:
+    @pytest.fixture
+    def sample_results(self) -> list[EvaluationResult]:
+        return [
+            EvaluationResult(
+                question="Q1",
+                expected_outcome="genuine_rag",
+                actual_outcome="genuine_rag",
+                confidence_score=0.95,
+            ),
+            EvaluationResult(
+                question="Q2",
+                expected_outcome="about_mps",
+                actual_outcome="about_mps",
+                confidence_score=0.9,
+            ),
+            EvaluationResult(
+                question="Q3",
+                expected_outcome="character_fun",
+                actual_outcome="genuine_rag",
+                confidence_score=0.5,
+            ),
+            EvaluationResult(
+                question="Q4",
+                expected_outcome="character_fun",
+                actual_outcome="about_mps",
+                confidence_score=0.3,
+            ),
+            EvaluationResult(
+                question="Q5",
+                expected_outcome="genuine_rag",
+                actual_outcome="genuine_rag",
+                confidence_score=0.5,
+            ),
+        ]
+
+    def test_classification_labels(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert aggregate.classification_labels == [
+            "about_mps",
+            "character_fun",
+            "genuine_rag",
+        ]
+
+    def test_accuracy_value(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert round(aggregate.accuracy(), 2) == 0.6
+
+    def test_precision_value(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert round(aggregate.precision(), 2) == 0.61
+
+    def test_recall_value(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert aggregate.recall() == 0.6
+
+    def test_f1_value(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert round(aggregate.f1_score(), 2) == 0.45
+
+    def test_f2_value(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert round(aggregate.f2_score(), 2) == 0.53
+
+    def test_miscategorised_cases(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        miscategorised = aggregate.miscategorised_cases()
+        print(miscategorised)
+
+        assert len(miscategorised) == 2
+        assert miscategorised[0] == {
+            "question": "Q3",
+            "predicted_classification": "character_fun",
+            "actual_classification": "genuine_rag",
+            "confidence_score": 0.5,
+        }
+        assert miscategorised[1] == {
+            "question": "Q4",
+            "predicted_classification": "character_fun",
+            "actual_classification": "about_mps",
+            "confidence_score": 0.3,
+        }
+
+    def test_to_dict(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        assert aggregate.to_dict() == {
+            "Evaluated": len(sample_results),
+            "Accuracy": aggregate.accuracy(),
+            "Precision": aggregate.precision(),
+            "Recall": aggregate.recall(),
+            "F1 Score": aggregate.f1_score(),
+            "F2 Score": aggregate.f2_score(),
+            "Miscategorised Cases": len(aggregate.miscategorised_cases()),
+        }
+
+    def test_for_csv(self, sample_results):
+        aggregate = AggregateResults(sample_results)
+        expected_csv = [
+            {"property": k, "value": v} for k, v in aggregate.to_dict().items()
+        ]
+        assert aggregate.for_csv() == expected_csv
+
+
+@pytest.fixture
+def mock_evaluation_data_file(tmp_path):
+    file_path = tmp_path / "evaluation_data.jsonl"
+    data = [
+        {
+            "question": "Question 1",
+            "expected_outcome": "genuine_rag",
+            "actual_outcome": "genuine_rag",
+            "confidence_score": 0.95,
+        },
+        {
+            "question": "Question 2",
+            "expected_outcome": "genuine_rag",
+            "actual_outcome": "about_mps",
+            "confidence_score": 0.95,
+        },
+    ]
+
+    with open(tmp_path / "evaluation_data.jsonl", "w", encoding="utf8") as file:
+        for item in data:
+            file.write(json.dumps(item) + "\n")
+
+    return file_path
+
+
+def test_evaluate_and_output_results_writes_results(
+    mock_project_root, mock_evaluation_data_file
+):
+    evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
+    results_file = mock_project_root / "results.csv"
+
+    assert results_file.exists()
+
+    with open(results_file, "r") as file:
+        reader = csv.reader(file)
+        headers = next(reader, None)
+
+        assert headers is not None
+        assert "question" in headers
+
+
+def test_evaluate_and_output_results_writes_aggregates(
+    mock_project_root, mock_evaluation_data_file
+):
+    evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
+    aggregates_file = mock_project_root / "aggregate.csv"
+
+    assert aggregates_file.exists()
+    with open(aggregates_file, "r") as file:
+        reader = csv.reader(file)
+        headers = next(reader, None)
+
+        assert headers is not None
+        assert "property" in headers
+
+
+def test_evaluate_and_output_results_writes_confusion_matrix(
+    mock_project_root, mock_evaluation_data_file
+):
+    evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
+    confusion_matrix_file = mock_project_root / "confusion_matrix.png"
+
+    assert confusion_matrix_file.exists()
+
+
+def test_evaluate_and_output_results_writes_miscategorised_cases(
+    mock_project_root, mock_evaluation_data_file
+):
+    evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
+    miscategorised_cases_file = mock_project_root / "miscategorised_cases.csv"
+
+    assert miscategorised_cases_file.exists()
+    with open(miscategorised_cases_file, "r") as file:
+        reader = csv.reader(file)
+        headers = next(reader, None)
+
+        assert headers is not None
+        assert "question" in headers
+        assert "predicted_classification" in headers
+        assert "actual_classification" in headers
+
+
+def test_evaluate_and_output_results_prints_aggregates(
+    mock_project_root, mock_evaluation_data_file, capsys
+):
+    evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
+
+    captured = capsys.readouterr()
+    assert "Aggregate Results" in captured.out
+    assert re.search(r"Evaluated\s+\d+", captured.out)

--- a/tests/question_router/test_generate.py
+++ b/tests/question_router/test_generate.py
@@ -1,0 +1,87 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from govuk_chat_evaluation.question_router.generate import (
+    generate_inputs_to_evaluation_results,
+    generate_and_write_dataset,
+    GenerateInput,
+    EvaluationResult,
+)
+
+
+@pytest.fixture
+def run_rake_task_mock(mocker):
+    async def default_side_effect(_, env):
+        if env["INPUT"] == "Question 1":
+            return {"classification": "genuine_rag", "confidence_score": 0.9}
+        else:
+            return {"classification": "greetings", "confidence_score": 0.8}
+
+    mock = mocker.patch(
+        "govuk_chat_evaluation.question_router.generate.run_rake_task",
+        new_callable=AsyncMock,
+    )
+    mock.side_effect = default_side_effect
+    return mock
+
+
+def test_generate_inputs_to_evaluation_results_returns_evaluation_results(
+    run_rake_task_mock,
+):
+    generate_inputs = [
+        GenerateInput(
+            question="Question 1",
+            expected_outcome="genuine_rag",
+        ),
+        GenerateInput(
+            question="Question 2",
+            expected_outcome="greetings",
+        ),
+    ]
+    expected_results = [
+        EvaluationResult(
+            question="Question 1",
+            expected_outcome="genuine_rag",
+            actual_outcome="genuine_rag",
+            confidence_score=0.9,
+        ),
+        EvaluationResult(
+            question="Question 2",
+            expected_outcome="greetings",
+            actual_outcome="greetings",
+            confidence_score=0.8,
+        ),
+    ]
+    actual_results = generate_inputs_to_evaluation_results("openai", generate_inputs)
+
+    assert sorted(expected_results, key=lambda r: r.question) == sorted(
+        actual_results, key=lambda r: r.question
+    )
+
+
+def test_generate_inputs_to_evaluation_results_runs_expected_rake_task(
+    run_rake_task_mock,
+):
+    generate_inputs = [
+        GenerateInput(
+            question="Question 1",
+            expected_outcome="genuine_rag",
+        ),
+    ]
+    generate_inputs_to_evaluation_results("openai", generate_inputs)
+
+    run_rake_task_mock.assert_called_with(
+        "evaluation:generate_question_routing_response[openai]",
+        {"INPUT": "Question 1"},
+    )
+
+
+@pytest.mark.usefixtures("run_rake_task_mock")
+def test_generate_and_write_dataset(mock_input_data, mock_project_root):
+    path = generate_and_write_dataset(mock_input_data, "openai", mock_project_root)
+    assert path.exists()
+    with open(path, "r") as file:
+        for line in file:
+            assert json.loads(line)

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,63 @@ wheels = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/c2/fc7193cc5383637ff390a712e88e4ded0452c9fbcf84abe3de5ea3df1866/contourpy-1.3.1.tar.gz", hash = "sha256:dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699", size = 13465753 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/e7/de62050dce687c5e96f946a93546910bc67e483fe05324439e329ff36105/contourpy-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a761d9ccfc5e2ecd1bf05534eda382aa14c3e4f9205ba5b1684ecfe400716ef2", size = 271548 },
+    { url = "https://files.pythonhosted.org/packages/78/4d/c2a09ae014ae984c6bdd29c11e74d3121b25eaa117eca0bb76340efd7e1c/contourpy-1.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:523a8ee12edfa36f6d2a49407f705a6ef4c5098de4f498619787e272de93f2d5", size = 255576 },
+    { url = "https://files.pythonhosted.org/packages/ab/8a/915380ee96a5638bda80cd061ccb8e666bfdccea38d5741cb69e6dbd61fc/contourpy-1.3.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece6df05e2c41bd46776fbc712e0996f7c94e0d0543af1656956d150c4ca7c81", size = 306635 },
+    { url = "https://files.pythonhosted.org/packages/29/5c/c83ce09375428298acd4e6582aeb68b1e0d1447f877fa993d9bf6cd3b0a0/contourpy-1.3.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:573abb30e0e05bf31ed067d2f82500ecfdaec15627a59d63ea2d95714790f5c2", size = 345925 },
+    { url = "https://files.pythonhosted.org/packages/29/63/5b52f4a15e80c66c8078a641a3bfacd6e07106835682454647aca1afc852/contourpy-1.3.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9fa36448e6a3a1a9a2ba23c02012c43ed88905ec80163f2ffe2421c7192a5d7", size = 318000 },
+    { url = "https://files.pythonhosted.org/packages/9a/e2/30ca086c692691129849198659bf0556d72a757fe2769eb9620a27169296/contourpy-1.3.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ea9924d28fc5586bf0b42d15f590b10c224117e74409dd7a0be3b62b74a501c", size = 322689 },
+    { url = "https://files.pythonhosted.org/packages/6b/77/f37812ef700f1f185d348394debf33f22d531e714cf6a35d13d68a7003c7/contourpy-1.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b75aa69cb4d6f137b36f7eb2ace9280cfb60c55dc5f61c731fdf6f037f958a3", size = 1268413 },
+    { url = "https://files.pythonhosted.org/packages/3f/6d/ce84e79cdd128542ebeb268f84abb4b093af78e7f8ec504676673d2675bc/contourpy-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:041b640d4ec01922083645a94bb3b2e777e6b626788f4095cf21abbe266413c1", size = 1326530 },
+    { url = "https://files.pythonhosted.org/packages/72/22/8282f4eae20c73c89bee7a82a19c4e27af9b57bb602ecaa00713d5bdb54d/contourpy-1.3.1-cp313-cp313-win32.whl", hash = "sha256:36987a15e8ace5f58d4d5da9dca82d498c2bbb28dff6e5d04fbfcc35a9cb3a82", size = 175315 },
+    { url = "https://files.pythonhosted.org/packages/e3/d5/28bca491f65312b438fbf076589dcde7f6f966b196d900777f5811b9c4e2/contourpy-1.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:a7895f46d47671fa7ceec40f31fae721da51ad34bdca0bee83e38870b1f47ffd", size = 220987 },
+    { url = "https://files.pythonhosted.org/packages/2f/24/a4b285d6adaaf9746e4700932f579f1a7b6f9681109f694cfa233ae75c4e/contourpy-1.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9ddeb796389dadcd884c7eb07bd14ef12408aaae358f0e2ae24114d797eede30", size = 285001 },
+    { url = "https://files.pythonhosted.org/packages/48/1d/fb49a401b5ca4f06ccf467cd6c4f1fd65767e63c21322b29b04ec40b40b9/contourpy-1.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:19c1555a6801c2f084c7ddc1c6e11f02eb6a6016ca1318dd5452ba3f613a1751", size = 268553 },
+    { url = "https://files.pythonhosted.org/packages/79/1e/4aef9470d13fd029087388fae750dccb49a50c012a6c8d1d634295caa644/contourpy-1.3.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:841ad858cff65c2c04bf93875e384ccb82b654574a6d7f30453a04f04af71342", size = 310386 },
+    { url = "https://files.pythonhosted.org/packages/b0/34/910dc706ed70153b60392b5305c708c9810d425bde12499c9184a1100888/contourpy-1.3.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4318af1c925fb9a4fb190559ef3eec206845f63e80fb603d47f2d6d67683901c", size = 349806 },
+    { url = "https://files.pythonhosted.org/packages/31/3c/faee6a40d66d7f2a87f7102236bf4780c57990dd7f98e5ff29881b1b1344/contourpy-1.3.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:14c102b0eab282427b662cb590f2e9340a9d91a1c297f48729431f2dcd16e14f", size = 321108 },
+    { url = "https://files.pythonhosted.org/packages/17/69/390dc9b20dd4bb20585651d7316cc3054b7d4a7b4f8b710b2b698e08968d/contourpy-1.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05e806338bfeaa006acbdeba0ad681a10be63b26e1b17317bfac3c5d98f36cda", size = 327291 },
+    { url = "https://files.pythonhosted.org/packages/ef/74/7030b67c4e941fe1e5424a3d988080e83568030ce0355f7c9fc556455b01/contourpy-1.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4d76d5993a34ef3df5181ba3c92fabb93f1eaa5729504fb03423fcd9f3177242", size = 1263752 },
+    { url = "https://files.pythonhosted.org/packages/f0/ed/92d86f183a8615f13f6b9cbfc5d4298a509d6ce433432e21da838b4b63f4/contourpy-1.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:89785bb2a1980c1bd87f0cb1517a71cde374776a5f150936b82580ae6ead44a1", size = 1318403 },
+    { url = "https://files.pythonhosted.org/packages/b3/0e/c8e4950c77dcfc897c71d61e56690a0a9df39543d2164040301b5df8e67b/contourpy-1.3.1-cp313-cp313t-win32.whl", hash = "sha256:8eb96e79b9f3dcadbad2a3891672f81cdcab7f95b27f28f1c67d75f045b6b4f1", size = 185117 },
+    { url = "https://files.pythonhosted.org/packages/c1/31/1ae946f11dfbd229222e6d6ad8e7bd1891d3d48bde5fbf7a0beb9491f8e3/contourpy-1.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:287ccc248c9e0d0566934e7d606201abd74761b5703d804ff3df8935f523d546", size = 236668 },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321 },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.57.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/2d/a9a0b6e3a0cf6bd502e64fc16d894269011930cabfc89aee20d1635b1441/fonttools-4.57.0.tar.gz", hash = "sha256:727ece10e065be2f9dd239d15dd5d60a66e17eac11aea47d447f9f03fdbc42de", size = 3492448 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/2f/11439f3af51e4bb75ac9598c29f8601aa501902dcedf034bdc41f47dd799/fonttools-4.57.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:408ce299696012d503b714778d89aa476f032414ae57e57b42e4b92363e0b8ef", size = 2739175 },
+    { url = "https://files.pythonhosted.org/packages/25/52/677b55a4c0972dc3820c8dba20a29c358197a78229daa2ea219fdb19e5d5/fonttools-4.57.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bbceffc80aa02d9e8b99f2a7491ed8c4a783b2fc4020119dc405ca14fb5c758c", size = 2276583 },
+    { url = "https://files.pythonhosted.org/packages/64/79/184555f8fa77b827b9460a4acdbbc0b5952bb6915332b84c615c3a236826/fonttools-4.57.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f022601f3ee9e1f6658ed6d184ce27fa5216cee5b82d279e0f0bde5deebece72", size = 4766437 },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/c25116352f456c0d1287545a7aa24e98987b6d99c5b0456c4bd14321f20f/fonttools-4.57.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dea5893b58d4637ffa925536462ba626f8a1b9ffbe2f5c272cdf2c6ebadb817", size = 4838431 },
+    { url = "https://files.pythonhosted.org/packages/53/ae/398b2a833897297797a44f519c9af911c2136eb7aa27d3f1352c6d1129fa/fonttools-4.57.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dff02c5c8423a657c550b48231d0a48d7e2b2e131088e55983cfe74ccc2c7cc9", size = 4951011 },
+    { url = "https://files.pythonhosted.org/packages/b7/5d/7cb31c4bc9ffb9a2bbe8b08f8f53bad94aeb158efad75da645b40b62cb73/fonttools-4.57.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:767604f244dc17c68d3e2dbf98e038d11a18abc078f2d0f84b6c24571d9c0b13", size = 5205679 },
+    { url = "https://files.pythonhosted.org/packages/4c/e4/6934513ec2c4d3d69ca1bc3bd34d5c69dafcbf68c15388dd3bb062daf345/fonttools-4.57.0-cp313-cp313-win32.whl", hash = "sha256:8e2e12d0d862f43d51e5afb8b9751c77e6bec7d2dc00aad80641364e9df5b199", size = 2144833 },
+    { url = "https://files.pythonhosted.org/packages/c4/0d/2177b7fdd23d017bcfb702fd41e47d4573766b9114da2fddbac20dcc4957/fonttools-4.57.0-cp313-cp313-win_amd64.whl", hash = "sha256:f1d6bc9c23356908db712d282acb3eebd4ae5ec6d8b696aa40342b1d84f8e9e3", size = 2190799 },
+    { url = "https://files.pythonhosted.org/packages/90/27/45f8957c3132917f91aaa56b700bcfc2396be1253f685bd5c68529b6f610/fonttools-4.57.0-py3-none-any.whl", hash = "sha256:3122c604a675513c68bd24c6a8f9091f1c2376d18e8f5fe5a101746c81b3e98f", size = 1093605 },
+]
+
+[[package]]
 name = "freezegun"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -50,10 +107,12 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
+    { name = "matplotlib" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "scikit-learn" },
+    { name = "seaborn" },
     { name = "tabulate" },
     { name = "tqdm" },
 ]
@@ -71,10 +130,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.8" },
+    { name = "matplotlib", specifier = ">=3.10" },
     { name = "numpy", specifier = ">=2.2.4" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
+    { name = "seaborn", specifier = ">=0.13.2" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
@@ -105,6 +166,73 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/33/60135848598c076ce4b231e1b1895170f45fbcaeaa2c9d5e38b04db70c35/joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e", size = 2116621 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/29/df4b9b42f2be0b623cbd5e2140cafcaa2bef0759a00b7b70104dcfe2fb51/joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6", size = 301817 },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.4.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/59/7c91426a8ac292e1cdd53a63b6d9439abd573c875c3f92c146767dd33faf/kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e", size = 97538 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/b3/e62464a652f4f8cd9006e13d07abad844a47df1e6537f73ddfbf1bc997ec/kiwisolver-1.4.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1c8ceb754339793c24aee1c9fb2485b5b1f5bb1c2c214ff13368431e51fc9a09", size = 124156 },
+    { url = "https://files.pythonhosted.org/packages/8d/2d/f13d06998b546a2ad4f48607a146e045bbe48030774de29f90bdc573df15/kiwisolver-1.4.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a62808ac74b5e55a04a408cda6156f986cefbcf0ada13572696b507cc92fa1", size = 66555 },
+    { url = "https://files.pythonhosted.org/packages/59/e3/b8bd14b0a54998a9fd1e8da591c60998dc003618cb19a3f94cb233ec1511/kiwisolver-1.4.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:68269e60ee4929893aad82666821aaacbd455284124817af45c11e50a4b42e3c", size = 65071 },
+    { url = "https://files.pythonhosted.org/packages/f0/1c/6c86f6d85ffe4d0ce04228d976f00674f1df5dc893bf2dd4f1928748f187/kiwisolver-1.4.8-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34d142fba9c464bc3bbfeff15c96eab0e7310343d6aefb62a79d51421fcc5f1b", size = 1378053 },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/1c6e9f6dcb103ac5cf87cb695845f5fa71379021500153566d8a8a9fc291/kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ddc373e0eef45b59197de815b1b28ef89ae3955e7722cc9710fb91cd77b7f47", size = 1472278 },
+    { url = "https://files.pythonhosted.org/packages/ee/81/aca1eb176de671f8bda479b11acdc42c132b61a2ac861c883907dde6debb/kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:77e6f57a20b9bd4e1e2cedda4d0b986ebd0216236f0106e55c28aea3d3d69b16", size = 1478139 },
+    { url = "https://files.pythonhosted.org/packages/49/f4/e081522473671c97b2687d380e9e4c26f748a86363ce5af48b4a28e48d06/kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08e77738ed7538f036cd1170cbed942ef749137b1311fa2bbe2a7fda2f6bf3cc", size = 1413517 },
+    { url = "https://files.pythonhosted.org/packages/8f/e9/6a7d025d8da8c4931522922cd706105aa32b3291d1add8c5427cdcd66e63/kiwisolver-1.4.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5ce1e481a74b44dd5e92ff03ea0cb371ae7a0268318e202be06c8f04f4f1246", size = 1474952 },
+    { url = "https://files.pythonhosted.org/packages/82/13/13fa685ae167bee5d94b415991c4fc7bb0a1b6ebea6e753a87044b209678/kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fc2ace710ba7c1dfd1a3b42530b62b9ceed115f19a1656adefce7b1782a37794", size = 2269132 },
+    { url = "https://files.pythonhosted.org/packages/ef/92/bb7c9395489b99a6cb41d502d3686bac692586db2045adc19e45ee64ed23/kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3452046c37c7692bd52b0e752b87954ef86ee2224e624ef7ce6cb21e8c41cc1b", size = 2425997 },
+    { url = "https://files.pythonhosted.org/packages/ed/12/87f0e9271e2b63d35d0d8524954145837dd1a6c15b62a2d8c1ebe0f182b4/kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e9a60b50fe8b2ec6f448fe8d81b07e40141bfced7f896309df271a0b92f80f3", size = 2376060 },
+    { url = "https://files.pythonhosted.org/packages/02/6e/c8af39288edbce8bf0fa35dee427b082758a4b71e9c91ef18fa667782138/kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:918139571133f366e8362fa4a297aeba86c7816b7ecf0bc79168080e2bd79957", size = 2520471 },
+    { url = "https://files.pythonhosted.org/packages/13/78/df381bc7b26e535c91469f77f16adcd073beb3e2dd25042efd064af82323/kiwisolver-1.4.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e063ef9f89885a1d68dd8b2e18f5ead48653176d10a0e324e3b0030e3a69adeb", size = 2338793 },
+    { url = "https://files.pythonhosted.org/packages/d0/dc/c1abe38c37c071d0fc71c9a474fd0b9ede05d42f5a458d584619cfd2371a/kiwisolver-1.4.8-cp313-cp313-win_amd64.whl", hash = "sha256:a17b7c4f5b2c51bb68ed379defd608a03954a1845dfed7cc0117f1cc8a9b7fd2", size = 71855 },
+    { url = "https://files.pythonhosted.org/packages/a0/b6/21529d595b126ac298fdd90b705d87d4c5693de60023e0efcb4f387ed99e/kiwisolver-1.4.8-cp313-cp313-win_arm64.whl", hash = "sha256:3cd3bc628b25f74aedc6d374d5babf0166a92ff1317f46267f12d2ed54bc1d30", size = 65430 },
+    { url = "https://files.pythonhosted.org/packages/34/bd/b89380b7298e3af9b39f49334e3e2a4af0e04819789f04b43d560516c0c8/kiwisolver-1.4.8-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:370fd2df41660ed4e26b8c9d6bbcad668fbe2560462cba151a721d49e5b6628c", size = 126294 },
+    { url = "https://files.pythonhosted.org/packages/83/41/5857dc72e5e4148eaac5aa76e0703e594e4465f8ab7ec0fc60e3a9bb8fea/kiwisolver-1.4.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:84a2f830d42707de1d191b9490ac186bf7997a9495d4e9072210a1296345f7dc", size = 67736 },
+    { url = "https://files.pythonhosted.org/packages/e1/d1/be059b8db56ac270489fb0b3297fd1e53d195ba76e9bbb30e5401fa6b759/kiwisolver-1.4.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7a3ad337add5148cf51ce0b55642dc551c0b9d6248458a757f98796ca7348712", size = 66194 },
+    { url = "https://files.pythonhosted.org/packages/e1/83/4b73975f149819eb7dcf9299ed467eba068ecb16439a98990dcb12e63fdd/kiwisolver-1.4.8-cp313-cp313t-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7506488470f41169b86d8c9aeff587293f530a23a23a49d6bc64dab66bedc71e", size = 1465942 },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/30a5cdde5102958e602c07466bce058b9d7cb48734aa7a4327261ac8e002/kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f0121b07b356a22fb0414cec4666bbe36fd6d0d759db3d37228f496ed67c880", size = 1595341 },
+    { url = "https://files.pythonhosted.org/packages/ff/9b/1e71db1c000385aa069704f5990574b8244cce854ecd83119c19e83c9586/kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d6d6bd87df62c27d4185de7c511c6248040afae67028a8a22012b010bc7ad062", size = 1598455 },
+    { url = "https://files.pythonhosted.org/packages/85/92/c8fec52ddf06231b31cbb779af77e99b8253cd96bd135250b9498144c78b/kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:291331973c64bb9cce50bbe871fb2e675c4331dab4f31abe89f175ad7679a4d7", size = 1522138 },
+    { url = "https://files.pythonhosted.org/packages/0b/51/9eb7e2cd07a15d8bdd976f6190c0164f92ce1904e5c0c79198c4972926b7/kiwisolver-1.4.8-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:893f5525bb92d3d735878ec00f781b2de998333659507d29ea4466208df37bed", size = 1582857 },
+    { url = "https://files.pythonhosted.org/packages/0f/95/c5a00387a5405e68ba32cc64af65ce881a39b98d73cc394b24143bebc5b8/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b47a465040146981dc9db8647981b8cb96366fbc8d452b031e4f8fdffec3f26d", size = 2293129 },
+    { url = "https://files.pythonhosted.org/packages/44/83/eeb7af7d706b8347548313fa3a3a15931f404533cc54fe01f39e830dd231/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:99cea8b9dd34ff80c521aef46a1dddb0dcc0283cf18bde6d756f1e6f31772165", size = 2421538 },
+    { url = "https://files.pythonhosted.org/packages/05/f9/27e94c1b3eb29e6933b6986ffc5fa1177d2cd1f0c8efc5f02c91c9ac61de/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:151dffc4865e5fe6dafce5480fab84f950d14566c480c08a53c663a0020504b6", size = 2390661 },
+    { url = "https://files.pythonhosted.org/packages/d9/d4/3c9735faa36ac591a4afcc2980d2691000506050b7a7e80bcfe44048daa7/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:577facaa411c10421314598b50413aa1ebcf5126f704f1e5d72d7e4e9f020d90", size = 2546710 },
+    { url = "https://files.pythonhosted.org/packages/4c/fa/be89a49c640930180657482a74970cdcf6f7072c8d2471e1babe17a222dc/kiwisolver-1.4.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:be4816dc51c8a471749d664161b434912eee82f2ea66bd7628bd14583a833e85", size = 2349213 },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/08/b89867ecea2e305f408fbb417139a8dd941ecf7b23a2e02157c36da546f0/matplotlib-3.10.1.tar.gz", hash = "sha256:e8d2d0e3881b129268585bf4765ad3ee73a4591d77b9a18c214ac7e3a79fb2ba", size = 36743335 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/73/6770ff5e5523d00f3bc584acb6031e29ee5c8adc2336b16cd1d003675fe0/matplotlib-3.10.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42eee41e1b60fd83ee3292ed83a97a5f2a8239b10c26715d8a6172226988d7b", size = 8176112 },
+    { url = "https://files.pythonhosted.org/packages/08/97/b0ca5da0ed54a3f6599c3ab568bdda65269bc27c21a2c97868c1625e4554/matplotlib-3.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4f0647b17b667ae745c13721602b540f7aadb2a32c5b96e924cd4fea5dcb90f1", size = 8046931 },
+    { url = "https://files.pythonhosted.org/packages/df/9a/1acbdc3b165d4ce2dcd2b1a6d4ffb46a7220ceee960c922c3d50d8514067/matplotlib-3.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa3854b5f9473564ef40a41bc922be978fab217776e9ae1545c9b3a5cf2092a3", size = 8453422 },
+    { url = "https://files.pythonhosted.org/packages/51/d0/2bc4368abf766203e548dc7ab57cf7e9c621f1a3c72b516cc7715347b179/matplotlib-3.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e496c01441be4c7d5f96d4e40f7fca06e20dcb40e44c8daa2e740e1757ad9e6", size = 8596819 },
+    { url = "https://files.pythonhosted.org/packages/ab/1b/8b350f8a1746c37ab69dda7d7528d1fc696efb06db6ade9727b7887be16d/matplotlib-3.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5d45d3f5245be5b469843450617dcad9af75ca50568acf59997bed9311131a0b", size = 9402782 },
+    { url = "https://files.pythonhosted.org/packages/89/06/f570373d24d93503988ba8d04f213a372fa1ce48381c5eb15da985728498/matplotlib-3.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:8e8e25b1209161d20dfe93037c8a7f7ca796ec9aa326e6e4588d8c4a5dd1e473", size = 8063812 },
+    { url = "https://files.pythonhosted.org/packages/fc/e0/8c811a925b5a7ad75135f0e5af46408b78af88bbb02a1df775100ef9bfef/matplotlib-3.10.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:19b06241ad89c3ae9469e07d77efa87041eac65d78df4fcf9cac318028009b01", size = 8214021 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/319ec2139f68ba26da9d00fce2ff9f27679fb799a6c8e7358539801fd629/matplotlib-3.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01e63101ebb3014e6e9f80d9cf9ee361a8599ddca2c3e166c563628b39305dbb", size = 8090782 },
+    { url = "https://files.pythonhosted.org/packages/77/ea/9812124ab9a99df5b2eec1110e9b2edc0b8f77039abf4c56e0a376e84a29/matplotlib-3.10.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f06bad951eea6422ac4e8bdebcf3a70c59ea0a03338c5d2b109f57b64eb3972", size = 8478901 },
+    { url = "https://files.pythonhosted.org/packages/c9/db/b05bf463689134789b06dea85828f8ebe506fa1e37593f723b65b86c9582/matplotlib-3.10.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3dfb036f34873b46978f55e240cff7a239f6c4409eac62d8145bad3fc6ba5a3", size = 8613864 },
+    { url = "https://files.pythonhosted.org/packages/c2/04/41ccec4409f3023a7576df3b5c025f1a8c8b81fbfe922ecfd837ac36e081/matplotlib-3.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dc6ab14a7ab3b4d813b88ba957fc05c79493a037f54e246162033591e770de6f", size = 9409487 },
+    { url = "https://files.pythonhosted.org/packages/ac/c2/0d5aae823bdcc42cc99327ecdd4d28585e15ccd5218c453b7bcd827f3421/matplotlib-3.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:bc411ebd5889a78dabbc457b3fa153203e22248bfa6eedc6797be5df0164dbf9", size = 8134832 },
 ]
 
 [[package]]
@@ -151,6 +279,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573 },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809 },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316 },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055 },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175 },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650 },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177 },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526 },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+]
+
+[[package]]
+name = "pillow"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz", hash = "sha256:368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20", size = 46742715 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/31/9ca79cafdce364fd5c980cd3416c20ce1bebd235b470d262f9d24d810184/pillow-11.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae98e14432d458fc3de11a77ccb3ae65ddce70f730e7c76140653048c71bfcbc", size = 3226640 },
+    { url = "https://files.pythonhosted.org/packages/ac/0f/ff07ad45a1f172a497aa393b13a9d81a32e1477ef0e869d030e3c1532521/pillow-11.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cc1331b6d5a6e144aeb5e626f4375f5b7ae9934ba620c0ac6b3e43d5e683a0f0", size = 3101437 },
+    { url = "https://files.pythonhosted.org/packages/08/2f/9906fca87a68d29ec4530be1f893149e0cb64a86d1f9f70a7cfcdfe8ae44/pillow-11.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:758e9d4ef15d3560214cddbc97b8ef3ef86ce04d62ddac17ad39ba87e89bd3b1", size = 4326605 },
+    { url = "https://files.pythonhosted.org/packages/b0/0f/f3547ee15b145bc5c8b336401b2d4c9d9da67da9dcb572d7c0d4103d2c69/pillow-11.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b523466b1a31d0dcef7c5be1f20b942919b62fd6e9a9be199d035509cbefc0ec", size = 4411173 },
+    { url = "https://files.pythonhosted.org/packages/b1/df/bf8176aa5db515c5de584c5e00df9bab0713548fd780c82a86cba2c2fedb/pillow-11.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9044b5e4f7083f209c4e35aa5dd54b1dd5b112b108648f5c902ad586d4f945c5", size = 4369145 },
+    { url = "https://files.pythonhosted.org/packages/de/7c/7433122d1cfadc740f577cb55526fdc39129a648ac65ce64db2eb7209277/pillow-11.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3764d53e09cdedd91bee65c2527815d315c6b90d7b8b79759cc48d7bf5d4f114", size = 4496340 },
+    { url = "https://files.pythonhosted.org/packages/25/46/dd94b93ca6bd555588835f2504bd90c00d5438fe131cf01cfa0c5131a19d/pillow-11.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31eba6bbdd27dde97b0174ddf0297d7a9c3a507a8a1480e1e60ef914fe23d352", size = 4296906 },
+    { url = "https://files.pythonhosted.org/packages/a8/28/2f9d32014dfc7753e586db9add35b8a41b7a3b46540e965cb6d6bc607bd2/pillow-11.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b5d658fbd9f0d6eea113aea286b21d3cd4d3fd978157cbf2447a6035916506d3", size = 4431759 },
+    { url = "https://files.pythonhosted.org/packages/33/48/19c2cbe7403870fbe8b7737d19eb013f46299cdfe4501573367f6396c775/pillow-11.1.0-cp313-cp313-win32.whl", hash = "sha256:f86d3a7a9af5d826744fabf4afd15b9dfef44fe69a98541f666f66fbb8d3fef9", size = 2291657 },
+    { url = "https://files.pythonhosted.org/packages/3b/ad/285c556747d34c399f332ba7c1a595ba245796ef3e22eae190f5364bb62b/pillow-11.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:593c5fd6be85da83656b93ffcccc2312d2d149d251e98588b14fbc288fd8909c", size = 2626304 },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/ef35a71163bf36db06e9c8729608f78dedf032fc8313d19bd4be5c2588f3/pillow-11.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:11633d58b6ee5733bde153a8dafd25e505ea3d32e261accd388827ee987baf65", size = 2375117 },
+    { url = "https://files.pythonhosted.org/packages/79/30/77f54228401e84d6791354888549b45824ab0ffde659bafa67956303a09f/pillow-11.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:70ca5ef3b3b1c4a0812b5c63c57c23b63e53bc38e758b37a951e5bc466449861", size = 3230060 },
+    { url = "https://files.pythonhosted.org/packages/ce/b1/56723b74b07dd64c1010fee011951ea9c35a43d8020acd03111f14298225/pillow-11.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8000376f139d4d38d6851eb149b321a52bb8893a88dae8ee7d95840431977081", size = 3106192 },
+    { url = "https://files.pythonhosted.org/packages/e1/cd/7bf7180e08f80a4dcc6b4c3a0aa9e0b0ae57168562726a05dc8aa8fa66b0/pillow-11.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ee85f0696a17dd28fbcfceb59f9510aa71934b483d1f5601d1030c3c8304f3c", size = 4446805 },
+    { url = "https://files.pythonhosted.org/packages/97/42/87c856ea30c8ed97e8efbe672b58c8304dee0573f8c7cab62ae9e31db6ae/pillow-11.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dd0e081319328928531df7a0e63621caf67652c8464303fd102141b785ef9547", size = 4530623 },
+    { url = "https://files.pythonhosted.org/packages/ff/41/026879e90c84a88e33fb00cc6bd915ac2743c67e87a18f80270dfe3c2041/pillow-11.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e63e4e5081de46517099dc30abe418122f54531a6ae2ebc8680bcd7096860eab", size = 4465191 },
+    { url = "https://files.pythonhosted.org/packages/e5/fb/a7960e838bc5df57a2ce23183bfd2290d97c33028b96bde332a9057834d3/pillow-11.1.0-cp313-cp313t-win32.whl", hash = "sha256:dda60aa465b861324e65a78c9f5cf0f4bc713e4309f83bc387be158b077963d9", size = 2295494 },
+    { url = "https://files.pythonhosted.org/packages/d7/6c/6ec83ee2f6f0fda8d4cf89045c6be4b0373ebfc363ba8538f8c999f63fcd/pillow-11.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ad5db5781c774ab9a9b2c4302bbf0c1014960a0a7be63278d13ae6fdf88126fe", size = 2631595 },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/41c21c6c8af92b9fea313aa47c75de49e2f9a467964ee33eb0135d47eb64/pillow-11.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:67cd427c68926108778a9005f2a04adbd5e67c442ed21d95389fe1d595458756", size = 2377651 },
 ]
 
 [[package]]
@@ -203,6 +385,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/54/295e38769133363d7ec4a5863a4d579f331728c71a6644ff1024ee529315/pydantic_core-2.33.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7b79af799630af263eca9ec87db519426d8c9b3be35016eddad1832bac812d87", size = 1813331 },
     { url = "https://files.pythonhosted.org/packages/4c/9c/0c8ea02db8d682aa1ef48938abae833c1d69bdfa6e5ec13b21734b01ae70/pydantic_core-2.33.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eabf946a4739b5237f4f56d77fa6668263bc466d06a8036c055587c130a46f7b", size = 1986653 },
     { url = "https://files.pythonhosted.org/packages/8e/4f/3fb47d6cbc08c7e00f92300e64ba655428c05c56b8ab6723bd290bae6458/pydantic_core-2.33.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8a1d581e8cdbb857b0e0e81df98603376c1a5c34dc5e54039dcc00f043df81e7", size = 1931234 },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120 },
 ]
 
 [[package]]
@@ -280,6 +471,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
 ]
 
 [[package]]
@@ -377,6 +577,20 @@ wheels = [
 ]
 
 [[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,4 +648,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]


### PR DESCRIPTION
https://trello.com/c/82aouRre/2377

This extends the evaluation to support question routing.

It works in much the same way as the existing evaluations in that it
calls the rake task from the Rails app to generate the evals, then
outputs the results in the same way. However there are a couple of
differences.

Firstly we output a confusion matrix diagram for the eval. This uses the
sklearn, seaborn and matplotlib dependencies to generate the image. It's
a visual way to quickly see how well the eval is performing.

Secondly we output a CSV of miscategorised cases, i.e. it just contains
the entries of questions which were classified incorrectly.

Here's an example data file to put in `data/question_router.jsonl`

```
{"question":"What is my UTR number?","expected_outcome":"vague_acronym_grammar"}
{"question":"When is Friday?","expected_outcome":"vague_acronym_grammar"}
{"question":"Who is the best MP","expected_outcome":"about_mps"}
{"question":"Hi","expected_outcome":"greetings"}
{"question":"Get outta here","expected_outcome":"harmful_vulgar_controversy"}
{"question":"How much is VAT currently?","expected_outcome":"genuine_rag"}
```

And to run the eval:

```bash
uv run govuk_chat_evaluation question_router
```
