### PR TITLE
Add logging module

### DIFF
--- a/govuk_chat_evaluation/dataset_generation.py
+++ b/govuk_chat_evaluation/dataset_generation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Callable, Awaitable
 
 from tqdm.asyncio import tqdm
+import logging
 
 
 async def run_rake_task(task_name: str, env_vars: dict[str, str] | None = None) -> Any:
@@ -53,7 +54,7 @@ async def generate_dataset(
     ]
     evaluations = []
 
-    print("Generating dataset")
+    logging.info("Generating dataset")
     for future in tqdm.as_completed(tasks, total=len(tasks)):
         try:
             evaluation = await future

--- a/govuk_chat_evaluation/file_system.py
+++ b/govuk_chat_evaluation/file_system.py
@@ -8,6 +8,7 @@ import yaml
 from pydantic import BaseModel
 
 from .config import BaseConfig
+import logging
 
 Model = TypeVar("Model", bound=BaseModel)
 
@@ -31,7 +32,7 @@ def create_output_directory(prefix: str, time: datetime) -> Path:
 
     relative_path = path.relative_to(project_root())
 
-    print(f"Created output directory at {relative_path}/")
+    logging.info(f"Created output directory at {relative_path}/")
 
     return path
 
@@ -59,7 +60,7 @@ def write_generated_to_output(output_dir: Path, generated: list[Model]) -> Path:
             file.write(model.model_dump_json() + "\n")
 
     relative_path = output_path.relative_to(project_root())
-    print(f"Wrote generated data to {relative_path}")
+    logging.info(f"Wrote generated data to {relative_path}")
 
     return output_path
 
@@ -71,7 +72,7 @@ def write_config_file_for_reuse(output_dir: Path, config: BaseConfig) -> Path:
         yaml.dump(config.model_dump(mode="json"), file, default_flow_style=False)
 
     relative_path = config_path.relative_to(project_root())
-    print(f"Wrote used config to {relative_path}")
+    logging.info(f"Wrote used config to {relative_path}")
 
     return config_path
 
@@ -94,6 +95,6 @@ def write_csv_results(
             writer.writerow(record)
 
     relative_path = csv_path.relative_to(project_root())
-    print(f"Wrote {data_label} to {relative_path}")
+    logging.info(f"Wrote {data_label} to {relative_path}")
 
     return csv_path

--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -7,6 +7,7 @@ from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
+from ..logging import setup_logging
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
 
@@ -40,6 +41,7 @@ def main(**cli_args):
     )
 
     output_dir = create_output_directory("jailbreak_guardrails", start_time)
+    setup_logging(output_dir)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/jailbreak_guardrails/cli.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/cli.py
@@ -6,10 +6,10 @@ import click
 from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
-from ..file_system import create_output_directory, write_config_file_for_reuse
-from ..logging import setup_logging
+from ..file_system import write_config_file_for_reuse
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
+from ..output import initialise_output
 
 
 class Config(BaseConfig):
@@ -40,8 +40,7 @@ def main(**cli_args):
         cli_args=cli_args,
     )
 
-    output_dir = create_output_directory("jailbreak_guardrails", start_time)
-    setup_logging(output_dir)
+    output_dir = initialise_output("jailbreak_guardrails", start_time)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/jailbreak_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/evaluate.py
@@ -9,6 +9,7 @@ from sklearn.metrics import precision_score, recall_score
 from tabulate import tabulate
 
 from ..file_system import jsonl_to_models, write_csv_results
+import logging
 
 
 class EvaluationResult(BaseModel):
@@ -82,7 +83,7 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     """Evaluate the data in the evaluation data file and write result files
     to the output paths, with aggregates written to STDOUT"""
 
-    print("\nEvaluation complete")
+    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
@@ -95,5 +96,5 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
         data_label="aggregates",
     )
     table = [[k, v] for k, v in aggregate_results.to_dict().items()]
-    print("\nAggregate Results")
-    print(tabulate(table) + "\n")
+    logging.info("\nAggregate Results")
+    logging.info(tabulate(table) + "\n")

--- a/govuk_chat_evaluation/logging.py
+++ b/govuk_chat_evaluation/logging.py
@@ -1,0 +1,24 @@
+import logging
+import sys
+from pathlib import Path
+
+
+def setup_logging(run_output_dir: Path) -> None:
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.DEBUG)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.INFO)
+    stream_handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(stream_handler)
+
+    file_handler = logging.FileHandler(run_output_dir / "run.log")
+    file_handler.setLevel(logging.WARNING)
+    file_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s  %(levelname)s  %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root.addHandler(file_handler)

--- a/govuk_chat_evaluation/output.py
+++ b/govuk_chat_evaluation/output.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from pathlib import Path
+
+from .file_system import create_output_directory
+from .logging import setup_logging
+
+
+def initialise_output(prefix: str, run_time: datetime) -> Path:
+    """
+    Create the timestamped results directory for this run and
+    configure logging so warnings and errors are captured
+    in <output_dir>/run.log.
+    """
+    output_dir = create_output_directory(prefix, run_time)
+    setup_logging(output_dir)
+    return output_dir

--- a/govuk_chat_evaluation/output_guardrails/cli.py
+++ b/govuk_chat_evaluation/output_guardrails/cli.py
@@ -6,10 +6,10 @@ import click
 from pydantic import Field, model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
-from ..file_system import create_output_directory, write_config_file_for_reuse
-from ..logging import setup_logging
+from ..file_system import write_config_file_for_reuse
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
+from ..output import initialise_output
 
 
 class Config(BaseConfig):
@@ -44,8 +44,7 @@ def main(**cli_args):
         cli_args=cli_args,
     )
 
-    output_dir = create_output_directory("output_guardrails", start_time)
-    setup_logging(output_dir)
+    output_dir = initialise_output("output_guardrails", start_time)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/output_guardrails/cli.py
+++ b/govuk_chat_evaluation/output_guardrails/cli.py
@@ -7,6 +7,7 @@ from pydantic import Field, model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
+from ..logging import setup_logging
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
 
@@ -44,6 +45,7 @@ def main(**cli_args):
     )
 
     output_dir = create_output_directory("output_guardrails", start_time)
+    setup_logging(output_dir)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -9,6 +9,7 @@ from sklearn.metrics import precision_score, recall_score
 from tabulate import tabulate
 
 from ..file_system import jsonl_to_models, write_csv_results
+import logging
 
 
 class EvaluationResult(BaseModel):
@@ -83,7 +84,7 @@ class AggregateResults:
 
 
 def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
-    print("\nEvaluation complete")
+    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
@@ -97,5 +98,5 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     )
 
     table = [[k, v] for k, v in aggregate_results.to_dict().items()]
-    print("Aggregate Results")
-    print(tabulate(table) + "\n")
+    logging.info("Aggregate Results")
+    logging.info(tabulate(table) + "\n")

--- a/govuk_chat_evaluation/question_router/cli.py
+++ b/govuk_chat_evaluation/question_router/cli.py
@@ -6,10 +6,10 @@ import click
 from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
-from ..file_system import create_output_directory, write_config_file_for_reuse
-from ..logging import setup_logging
+from ..file_system import write_config_file_for_reuse
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
+from ..output import initialise_output
 
 
 class Config(BaseConfig):
@@ -40,8 +40,7 @@ def main(**cli_args):
         cli_args=cli_args,
     )
 
-    output_dir = create_output_directory("question_router", start_time)
-    setup_logging(output_dir)
+    output_dir = initialise_output("question_router", start_time)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/question_router/cli.py
+++ b/govuk_chat_evaluation/question_router/cli.py
@@ -7,6 +7,7 @@ from pydantic import model_validator
 
 from ..config import BaseConfig, config_from_cli_args, apply_click_options_to_command
 from ..file_system import create_output_directory, write_config_file_for_reuse
+from ..logging import setup_logging
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
 
@@ -40,6 +41,7 @@ def main(**cli_args):
     )
 
     output_dir = create_output_directory("question_router", start_time)
+    setup_logging(output_dir)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/question_router/evaluate.py
+++ b/govuk_chat_evaluation/question_router/evaluate.py
@@ -17,6 +17,7 @@ import seaborn as sns
 import numpy as np
 
 from ..file_system import jsonl_to_models, write_csv_results
+import logging
 
 
 class EvaluationResult(BaseModel):
@@ -151,7 +152,7 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     """Evaluate the data in the evaluation data file and write result files
     to the output paths, with aggregates written to STDOUT"""
 
-    print("\nEvaluation complete")
+    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
@@ -178,5 +179,5 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     )
 
     table = [[k, v] for k, v in aggregate_results.to_dict().items()]
-    print("\nAggregate Results")
-    print(tabulate(table) + "\n")
+    logging.info("\nAggregate Results")
+    logging.info(tabulate(table) + "\n")

--- a/govuk_chat_evaluation/rag_answers/cli.py
+++ b/govuk_chat_evaluation/rag_answers/cli.py
@@ -5,10 +5,11 @@ from typing import cast
 import click
 
 from ..config import apply_click_options_to_command, config_from_cli_args
-from ..file_system import create_output_directory, write_config_file_for_reuse
+from ..file_system import write_config_file_for_reuse
 from .evaluate import evaluate_and_output_results
 from .generate import generate_and_write_dataset
 from .data_models import Config
+from ..output import initialise_output
 
 
 @click.command(name="rag_answers")
@@ -28,7 +29,7 @@ def main(**cli_args):
         cli_args=cli_args,
     )
 
-    output_dir = create_output_directory("rag_answers", start_time)
+    output_dir = initialise_output("rag_answers", start_time)
 
     if config.generate:
         evaluate_path = generate_and_write_dataset(

--- a/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/deepeval_evaluate.py
@@ -6,7 +6,8 @@ from deepeval.metrics import BaseMetric
 from deepeval.test_case import LLMTestCase
 
 from .data_models import EvaluationResult, RunMetricOutput
-from ..timing import print_task_duration
+from ..timing import log_task_duration
+import logging
 
 
 def run_deepeval_evaluation(
@@ -26,13 +27,13 @@ def run_deepeval_evaluation(
 
     """
 
-    with print_task_duration("Running Deepval Evaluation"):
-        print("Running Deepval evaluation")
+    with log_task_duration("Running Deepval Evaluation"):
+        logging.info("Running Deepval evaluation")
 
         all_evaluation_runs = []
 
         for i in range(n_runs):
-            print(f"Running evaluation iteration {i + 1}/{n_runs}...")
+            logging.info(f"Running evaluation iteration {i + 1}/{n_runs}...")
 
             evaluation_run = deepeval_evaluate(
                 test_cases=cases,
@@ -44,7 +45,7 @@ def run_deepeval_evaluation(
                 evaluation_run.test_results
             )  # Store results per run
 
-    print("Deepval evaluation complete")
+    logging.info("Deepval evaluation complete")
 
     return all_evaluation_runs
 

--- a/govuk_chat_evaluation/rag_answers/evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/evaluate.py
@@ -18,6 +18,7 @@ from .deepeval_evaluate import (
 )
 from ..file_system import jsonl_to_models
 from .data_models import EvaluationTestCase, Config, EvaluationResult
+import logging
 
 
 display_config = DisplayConfig(
@@ -76,8 +77,8 @@ def evaluate_and_output_results(
     # calculate aggregated results and exports results to CSV files
     aggregation.export_to_csvs(output_dir)
 
-    print("Evaluation Results:")
-    print(aggregation.summary)
+    logging.info("Evaluation Results:")
+    logging.info(aggregation.summary)
 
 
 class AggregatedResults:

--- a/govuk_chat_evaluation/timing.py
+++ b/govuk_chat_evaluation/timing.py
@@ -1,13 +1,14 @@
 import time
 from contextlib import contextmanager
+import logging
 
 
 @contextmanager
-def print_task_duration(label: str = "Execution"):
+def log_task_duration(label: str = "Execution"):
     start_time = time.perf_counter()
     try:
         yield
     finally:
         end_time = time.perf_counter()
         duration = end_time - start_time
-        print(f"[{label}] took {duration:.4f} seconds")
+        logging.info(f"[{label}] took {duration:.4f} seconds")

--- a/tests/jailbreak_guardrails/test_evaluate.py
+++ b/tests/jailbreak_guardrails/test_evaluate.py
@@ -4,6 +4,7 @@ import re
 
 import numpy as np
 import pytest
+import logging
 
 from govuk_chat_evaluation.jailbreak_guardrails.evaluate import (
     AggregateResults,
@@ -215,10 +216,10 @@ def test_evaluate_and_output_results_writes_aggregates(
 
 
 def test_evaluate_and_output_results_prints_aggregates(
-    mock_project_root, mock_evaluation_data_file, capsys
+    mock_project_root, mock_evaluation_data_file, caplog
 ):
+    caplog.set_level(logging.INFO)
     evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
 
-    captured = capsys.readouterr()
-    assert "Aggregate Results" in captured.out
-    assert re.search(r"Evaluated\s+\d+", captured.out)
+    assert "Aggregate Results" in caplog.text
+    assert re.search(r"Evaluated\s+\d+", caplog.text)

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -4,6 +4,7 @@ import re
 
 import numpy as np
 import pytest
+import logging
 
 from govuk_chat_evaluation.output_guardrails.evaluate import (
     AggregateResults,
@@ -235,10 +236,10 @@ def test_evaluate_and_output_results_writes_aggregates(
 
 
 def test_evaluate_and_output_results_prints_aggregates(
-    mock_project_root, mock_evaluation_data_file, capsys
+    mock_project_root, mock_evaluation_data_file, caplog
 ):
+    caplog.set_level(logging.INFO)
     evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
 
-    captured = capsys.readouterr()
-    assert "Aggregate Results" in captured.out
-    assert re.search(r"Evaluated\s+\d+", captured.out)
+    assert "Aggregate Results" in caplog.text
+    assert re.search(r"Evaluated\s+\d+", caplog.text)

--- a/tests/question_router/test_evaluate.py
+++ b/tests/question_router/test_evaluate.py
@@ -215,10 +215,10 @@ def test_evaluate_and_output_results_writes_miscategorised_cases(
 
 
 def test_evaluate_and_output_results_prints_aggregates(
-    mock_project_root, mock_evaluation_data_file, capsys
+    mock_project_root, mock_evaluation_data_file, caplog
 ):
+    caplog.set_level(logging.INFO)
     evaluate_and_output_results(mock_project_root, mock_evaluation_data_file)
 
-    captured = capsys.readouterr()
-    assert "Aggregate Results" in captured.out
-    assert re.search(r"Evaluated\s+\d+", captured.out)
+    assert "Aggregate Results" in caplog.text
+    assert re.search(r"Evaluated\s+\d+", caplog.text)

--- a/tests/question_router/test_evaluate.py
+++ b/tests/question_router/test_evaluate.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import re
+import logging
 
 import pytest
 
@@ -95,7 +96,7 @@ class TestAggregateResults:
     def test_miscategorised_cases(self, sample_results):
         aggregate = AggregateResults(sample_results)
         miscategorised = aggregate.miscategorised_cases()
-        print(miscategorised)
+        logging.info(miscategorised)
 
         assert len(miscategorised) == 2
         assert miscategorised[0] == {

--- a/tests/rag_answers/test_evaluate.py
+++ b/tests/rag_answers/test_evaluate.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd
 import re
 import yaml
+import logging
 
 from govuk_chat_evaluation.rag_answers.data_models import (
     Config,
@@ -126,10 +127,11 @@ def test_evaluate_and_output_results_writes_results_to_disk(
 
 @pytest.mark.usefixtures("mock_run_deepeval_evaluation")
 def test_evaluate_and_output_results_prints_summary(
-    tmp_path, mock_input_data, mock_evaluation_config, capsys
+    tmp_path, mock_input_data, mock_evaluation_config, caplog
 ):
+    caplog.set_level(logging.INFO)
     evaluate_and_output_results(tmp_path, mock_input_data, mock_evaluation_config)
 
-    captured = capsys.readouterr()
-    assert "Evaluation Results:" in captured.out
-    assert re.search(r"median\s+mean\s+std", captured.out)
+    captured = caplog.text
+    assert "Evaluation Results:" in captured
+    assert re.search(r"median\s+mean\s+std", captured)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,33 @@
+import logging
+from pathlib import Path
+
+from govuk_chat_evaluation.logging import setup_logging
+
+
+def _read_file(path: Path) -> str:
+    with open(path, encoding="utf8") as fh:
+        return fh.read()
+
+
+def test_warning_is_written_to_log_file(tmp_path: Path, caplog):
+    setup_logging(tmp_path)
+    logger = logging.getLogger(__name__)
+
+    with caplog.at_level(logging.WARNING):
+        logger.warning("Incorrect LLM response: %s", "bad response")
+
+    log_file = tmp_path / "run.log"
+    assert log_file.exists()
+    file_contents = _read_file(log_file)
+    assert "Incorrect LLM response: bad response" in file_contents
+    assert "WARNING" in file_contents
+
+
+def test_info_does_not_land_in_log_file(tmp_path: Path):
+    setup_logging(tmp_path)
+    logging.getLogger(__name__).info("stdout info message")
+
+    log_file = tmp_path / "run.log"
+
+    assert log_file.exists()
+    assert "stdout info message" not in _read_file(log_file)


### PR DESCRIPTION
This PR Introduces a new module `govuk_chat_evaluation.logging` with a `setup_logging` function. This function configures two handlers:

-   A `StreamHandler` sending `INFO` level logs and above to stdout (formatted simply as the message).
-   A `FileHandler` sending `WARNING` level logs and above to a `run.log` file within the run's output directory (with a more detailed format including timestamp, level, and logger name).

Other changes:
- `setup_logging` is called the start of each CLI entry point (`main` function in `cli.py` files)
-   Replaced `print` calls throughout the application code with `logging.info` or `logging.warning` as appropriate.
-   Updated tests that previously used `capsys` to capture stdout to now use `caplog` to capture log messages.
-   Added new tests for the `govuk_chat_evaluation.logging` module (`tests/test_logging.py`).