### PR TITLE
Refactor jailbreak guardrails for handling error responses

### DIFF
--- a/govuk_chat_evaluation/dataset_generation.py
+++ b/govuk_chat_evaluation/dataset_generation.py
@@ -58,7 +58,8 @@ async def generate_dataset(
     for future in tqdm.as_completed(tasks, total=len(tasks)):
         try:
             evaluation = await future
-            evaluations.append(evaluation)
+            if evaluation is not None:
+                evaluations.append(evaluation)
         except Exception as e:
             # Cancel all remaining tasks to ensure clean termination
             for task in tasks:

--- a/tests/test_dataset_generation.py
+++ b/tests/test_dataset_generation.py
@@ -70,14 +70,16 @@ async def test_run_rake_task_failure(mocker):
 @pytest.mark.asyncio
 async def test_generate_dataset():
     async def mock_generation_func(item):
-        return {"input": item, "output": f"generated-{item}"}
+        if item == "question2":
+            return None
+        else:
+            return {"input": item, "output": f"generated-{item}"}
 
     ground_truth = ["question1", "question2", "question3"]
     result = await generate_dataset(ground_truth, mock_generation_func)
 
     expected_result = [
         {"input": "question1", "output": "generated-question1"},
-        {"input": "question2", "output": "generated-question2"},
         {"input": "question3", "output": "generated-question3"},
     ]
 


### PR DESCRIPTION
This changes the handling of the
evaluation:generate_jailbreak_guardrail_response rake task to reflect that it now returns success or response_error as changed in https://github.com/alphagov/govuk-chat/pull/200.

It is now configured so that when an response_error is returned the value of this is logged and it isn't included in the results.

A notable change of this is that it is now somewhat possible to get the results where none can be processed - which is a situation that currently errors.