### PR TITLE
Rename logfile from run.log to problems.log

### DIFF
--- a/govuk_chat_evaluation/logging.py
+++ b/govuk_chat_evaluation/logging.py
@@ -13,7 +13,7 @@ def setup_logging(run_output_dir: Path) -> None:
     stream_handler.setFormatter(logging.Formatter("%(message)s"))
     root.addHandler(stream_handler)
 
-    file_handler = logging.FileHandler(run_output_dir / "run.log")
+    file_handler = logging.FileHandler(run_output_dir / "problems.log")
     file_handler.setLevel(logging.WARNING)
     file_handler.setFormatter(
         logging.Formatter(

--- a/govuk_chat_evaluation/output.py
+++ b/govuk_chat_evaluation/output.py
@@ -9,7 +9,7 @@ def initialise_output(prefix: str, run_time: datetime) -> Path:
     """
     Create the timestamped results directory for this run and
     configure logging so warnings and errors are captured
-    in <output_dir>/run.log.
+    in <output_dir>/problems.log.
     """
     output_dir = create_output_directory(prefix, run_time)
     setup_logging(output_dir)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -16,7 +16,7 @@ def test_warning_is_written_to_log_file(tmp_path: Path, caplog):
     with caplog.at_level(logging.WARNING):
         logger.warning("Incorrect LLM response: %s", "bad response")
 
-    log_file = tmp_path / "run.log"
+    log_file = tmp_path / "problems.log"
     assert log_file.exists()
     file_contents = _read_file(log_file)
     assert "Incorrect LLM response: bad response" in file_contents
@@ -27,7 +27,7 @@ def test_info_does_not_land_in_log_file(tmp_path: Path):
     setup_logging(tmp_path)
     logging.getLogger(__name__).info("stdout info message")
 
-    log_file = tmp_path / "run.log"
+    log_file = tmp_path / "problems.log"
 
     assert log_file.exists()
     assert "stdout info message" not in _read_file(log_file)


### PR DESCRIPTION
In discussions for
https://github.com/alphagov/govuk-chat-evaluation-prototype/pull/30 we debated whether we'd record all log information in the log file or just warnings/errors. We decided we'd name it run.log when we thought it'd have all the information and didn't then rename it when we decided on only storing warnings/errors. This renames it to be a big more descriptive.