### PR TITLE
Prevent evaluations crashing on no data

### DIFF
--- a/govuk_chat_evaluation/jailbreak_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/jailbreak_guardrails/evaluate.py
@@ -83,8 +83,13 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     """Evaluate the data in the evaluation data file and write result files
     to the output paths, with aggregates written to STDOUT"""
 
-    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
+
+    if not models:
+        logging.error("\nThere is no data to evaluate")
+        return
+
+    logging.info("\nEvaluation complete")
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
     aggregate_results = AggregateResults(models)

--- a/govuk_chat_evaluation/output_guardrails/evaluate.py
+++ b/govuk_chat_evaluation/output_guardrails/evaluate.py
@@ -84,8 +84,13 @@ class AggregateResults:
 
 
 def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
-    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
+
+    if not models:
+        logging.error("\nThere is no data to evaluate")
+        return
+
+    logging.info("\nEvaluation complete")
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
     aggregate_results = AggregateResults(models)

--- a/govuk_chat_evaluation/question_router/evaluate.py
+++ b/govuk_chat_evaluation/question_router/evaluate.py
@@ -152,8 +152,13 @@ def evaluate_and_output_results(output_dir: Path, evaluation_data_path: Path):
     """Evaluate the data in the evaluation data file and write result files
     to the output paths, with aggregates written to STDOUT"""
 
-    logging.info("\nEvaluation complete")
     models = jsonl_to_models(evaluation_data_path, EvaluationResult)
+
+    if not models:
+        logging.error("\nThere is no data to evaluate")
+        return
+
+    logging.info("\nEvaluation complete")
     write_csv_results(output_dir, [model.for_csv() for model in models])
 
     aggregate_results = AggregateResults(models)

--- a/govuk_chat_evaluation/rag_answers/evaluate.py
+++ b/govuk_chat_evaluation/rag_answers/evaluate.py
@@ -58,6 +58,10 @@ def evaluate_and_output_results(
 
     models = jsonl_to_models(evaluation_data_path, EvaluationTestCase)
 
+    if not models:
+        logging.error("\nThere is no data to evaluate")
+        return
+
     evaluation_outputs = run_deepeval_evaluation(
         cases=[model.to_llm_test_case() for model in models],
         metrics=cast(list[BaseMetric], evaluation_config.metric_instances()),

--- a/tests/jailbreak_guardrails/test_evaluate.py
+++ b/tests/jailbreak_guardrails/test_evaluate.py
@@ -223,3 +223,15 @@ def test_evaluate_and_output_results_prints_aggregates(
 
     assert "Aggregate Results" in caplog.text
     assert re.search(r"Evaluated\s+\d+", caplog.text)
+
+
+def test_evaluate_and_output_results_copes_with_empty_data(
+    mock_project_root, tmp_path, caplog
+):
+    caplog.set_level(logging.ERROR)
+    file_path = tmp_path / "evaluation_data.jsonl"
+    file_path.touch()
+
+    evaluate_and_output_results(mock_project_root, file_path)
+
+    assert "There is no data to evaluate" in caplog.text

--- a/tests/output_guardrails/test_evaluate.py
+++ b/tests/output_guardrails/test_evaluate.py
@@ -243,3 +243,15 @@ def test_evaluate_and_output_results_prints_aggregates(
 
     assert "Aggregate Results" in caplog.text
     assert re.search(r"Evaluated\s+\d+", caplog.text)
+
+
+def test_evaluate_and_output_results_copes_with_empty_data(
+    mock_project_root, tmp_path, caplog
+):
+    caplog.set_level(logging.ERROR)
+    file_path = tmp_path / "evaluation_data.jsonl"
+    file_path.touch()
+
+    evaluate_and_output_results(mock_project_root, file_path)
+
+    assert "There is no data to evaluate" in caplog.text

--- a/tests/question_router/test_evaluate.py
+++ b/tests/question_router/test_evaluate.py
@@ -222,3 +222,15 @@ def test_evaluate_and_output_results_prints_aggregates(
 
     assert "Aggregate Results" in caplog.text
     assert re.search(r"Evaluated\s+\d+", caplog.text)
+
+
+def test_evaluate_and_output_results_copes_with_empty_data(
+    mock_project_root, tmp_path, caplog
+):
+    caplog.set_level(logging.ERROR)
+    file_path = tmp_path / "evaluation_data.jsonl"
+    file_path.touch()
+
+    evaluate_and_output_results(mock_project_root, file_path)
+
+    assert "There is no data to evaluate" in caplog.text

--- a/tests/rag_answers/test_evaluate.py
+++ b/tests/rag_answers/test_evaluate.py
@@ -135,3 +135,15 @@ def test_evaluate_and_output_results_prints_summary(
     captured = caplog.text
     assert "Evaluation Results:" in captured
     assert re.search(r"median\s+mean\s+std", captured)
+
+
+def test_evaluate_and_output_results_copes_with_empty_data(
+    mock_project_root, tmp_path, mock_evaluation_config, caplog
+):
+    caplog.set_level(logging.ERROR)
+    file_path = tmp_path / "evaluation_data.jsonl"
+    file_path.touch()
+
+    evaluate_and_output_results(mock_project_root, file_path, mock_evaluation_config)
+
+    assert "There is no data to evaluate" in caplog.text


### PR DESCRIPTION
In https://github.com/alphagov/govuk-chat-evaluation-prototype/pull/31 I made changes that helped enable a scenario where an evaluation could try proceed without any data. This would result in a rather cryptic crash:

```
govuk_chat_evaluation/jailbreak_guardrails/evaluate.py:88: in evaluate_and_output_results
    write_csv_results(output_dir, [model.for_csv() for model in models])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

output_dir = PosixPath('/private/var/folders/b5/7hpxzxb53pd8xfkr5n_gdc5w0000gp/T/pytest-of-kevin.dew/pytest-31/test_evaluate_and_output_resul3')
data = [], filename = 'results.csv', data_label = 'results'

    def write_csv_results(
        output_dir: Path,
        data: list[dict[str, Any]],
        filename="results.csv",
        data_label="results",
    ) -> Path:
        """Take a list of dictionaries and use them to create a CSV file that is
        written to the output directory with the given filename"""
        csv_path = output_dir / filename
        with open(csv_path, "w", encoding="utf8") as file:
>           headers = data[0].keys()
E           IndexError: list index out of range

govuk_chat_evaluation/file_system.py:90: IndexError
```

This adds conditionals that check for the empty data and exit before reaching scenarios where errors could occur.