### PR TITLE
Configure uv as a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Install [uv](https://docs.astral.sh/uv/) to get started.
 ### Dependencies
 
 Run `uv sync` to install dependencies.  
-Run `uv pip install -e .` to install the executable.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dev = [
     "typeguard>=4.4.2",
 ]
 
+
+[tool.uv]
+package = true
+
 [project.scripts]
 govuk_chat_evaluation = "govuk_chat_evaluation.cli:main"
 

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 [[package]]
 name = "govuk-chat-evaluation-prototype"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "deepeval" },


### PR DESCRIPTION
We can avoid the manual step of `uv pip install -e .` by flagging to uv that this project is a package.

This also resolves a warning that was being flagged on `uv sync` of:

```
warning: Skipping installation of entry points (`project.scripts`) because this project is not packaged; to install entry points, set `tool.uv.package = true` or define a `build-system`
```

As we had a choice of how to resolve this warning,  I went with the simpler uv approach given the expectation is that people use `uv` to run this project.