### PR TITLE
Documentation updates to remove the prototype label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,11 @@ wheels/
 
 # Private data
 /data/*
-!/data/.keep
+!/data/README.md
 /results/*
-!/results/.keep
+!/results/README.md
 
 # configs
 /config/*
+!/config/README.md
 !/config/defaults

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Run `uv sync` to install dependencies.
 
 Evaluation tasks that generate responses from GOV.UK Chat require the application to be available in your `~/govuk` directory.
 
+The means to access input data is documented in [data/README.md](data/README.md).
+
 ### Usage
 
 Run `uv run govuk_chat_evaluation` to view available evaluation tasks and options.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# GOV.UK Chat Evaluation (Prototype)
+# GOV.UK Chat Evaluation
 
-A prototype to explore standardising the approach we use to evaluation on [GOV.UK Chat](https://github.com/alphagov/govuk-chat).
+A CLI tool to run evaluation tasks on [GOV.UK Chat](https://github.com/alphagov/govuk-chat). Tasks typically take a dataset of user input and expected output, they then generate actual user output from GOV.UK Chat, finally the actual output is compared with expected output to produce results.
 
 ## Nomenclature
 
-TBC
+- Evaluation - the process of comparing the expected output and actual output to measure the quality of the actual output
+- Config - a mechanism to alter parameters and options for an individual evaluation
+- Dataset - a collection of data that contains input and expected output, may also contain actual output
+- Generate - the process of taking user input and generating the actual output with GOV.UK Chat
+- Results - data that is produced from an individual evaluation to provide qualitative insights 
 
 ## Technical documentation
 
@@ -14,9 +18,11 @@ Install [uv](https://docs.astral.sh/uv/) to get started.
 
 Run `uv sync` to install dependencies.  
 
+Evaluation tasks that generate responses from GOV.UK Chat require the application to be available in your `~/govuk` directory.
+
 ### Usage
 
-Run `uv run govuk_chat_evaluation` to run an evaluation.
+Run `uv run govuk_chat_evaluation` to view available evaluation tasks and options.
 
 ### Development tasks
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,15 @@
+# GOV.UK Chat Evaluation
+
+## Config
+
+This directory is for storing config files used for evaluations. 
+
+The ones in the default directory are committed to the repository whereas other files within it, or within other directories, will only be available on your local system.
+
+Make changes to the default files if you want to affect how someone typically runs an evaluation or for a common evaluation scenario. For your own specific testing, use other locations.
+
+A couple of usage tips:
+
+- simple options in config files can typically be overridden with command line arguments when running a task, often reducing the need to create new config files (for example, a task with `generate: true` can be overridden with a `--no-generate` CLI option) - run `--help` against the task for options
+- whenever an evaluation is run a config file for that generation is stored in the results directory and can be used again to repeat the same configuration.
+

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+# GOV.UK Chat Evaluation
+
+## Data
+
+This directory should contain input data for evaluation. The contents are purposefully git ignored as this data can be sensitive.
+
+We have the data stored on [Google Drive](https://docs.google.com/document/d/1tfgY8-5hCZDqw5zYAVpgYgB-VtjCKlzk1l1HMdOVV8U/edit?tab=t.0#heading=h.9awg20g181xc) which AI Team members can access. It is expected that files from Google Drive will be saved to this directory to run an evaluation.

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,8 @@
+# GOV.UK Chat Evaluation
+
+## Results
+
+This directory is intended for storing the results of an individual evaluation. The contents are purposefully git ignored.
+
+Typically an individual result will contain data that allow re-running aspects of the evaluation. This includes a config file containing the configuration that was used for the evaluation and a file of the input dataset (including anything generated) which can be reused to run an evaluation again without re-generating the actual output.
+


### PR DESCRIPTION
This updates the main README and adds additional READMEs for the somewhat confusing empty directories. 

This has been done as a precursor ahead of removing the prototype label from this repo.